### PR TITLE
feat: Add new client kit for GA4 events to be sent server side

### DIFF
--- a/packages/GA4Client/package-lock.json
+++ b/packages/GA4Client/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mparticle/web-google-analytics-4-kit",
+  "name": "@mparticle/web-google-analytics-4-client-kit",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/packages/GA4Client/package.json
+++ b/packages/GA4Client/package.json
@@ -2,14 +2,17 @@
   "name": "@mparticle/web-google-analytics-4-client-kit",
   "version": "1.0.0",
   "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
-  "description": "mParticle integration sdk for Google Adwords",
+  "description": "mParticle integration sdk for Google Analytics",
   "main": "dist/GoogleAnalytics4EventForwarder-Kit.common.js",
-  "browser": "dist/GoogleAnalytics4EventForwarder-Kit.common.js",
+  "browser": "dist/GoogleAnalytics4EventForwarder-Kit.iife.js",
   "scripts": {
     "test": "node test/boilerplate/test-karma.js",
     "build": "ENVIRONMENT=production rollup --config rollup.config.js",
     "watch": "ENVIRONMENT=production rollup --config rollup.config.js -w",
     "testEndToEnd": "ENVIRONMENT=testEndToEnd rollup --config rollup.config.js && open http://localhost:8082/node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.html && node node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/server"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "devDependencies": {
     "@mparticle/web-kit-wrapper": "^1.0.5",

--- a/packages/GA4Client/rollup.config.js
+++ b/packages/GA4Client/rollup.config.js
@@ -14,7 +14,7 @@ const productionBuilds = {
         output: {
             ...production.output,
             format: 'iife',
-            file: `dist/${initialization.name}-Kit.iife.js`,
+            file: `dist/${initialization.name}ClientSide-Kit.iife.js`,
             name: `${initialization.name}Kit`,
         },
         plugins: [...production.plugins],
@@ -24,29 +24,10 @@ const productionBuilds = {
         output: {
             ...production.output,
             format: 'cjs',
-            file: `dist/${initialization.name}-Kit.common.js`,
+            file: `dist/${initialization.name}ClientSide-Kit.common.js`,
             name: `${initialization.name}Kit`,
         },
         plugins: [...production.plugins],
-    },
-    server_iife: {
-        input: './server-src/index.js',
-        output: {
-            ...production.output,
-            format: 'iife',
-            file: `dist/${initialization.name}ServerSide-Kit.iife.js`,
-            name: `${initialization.name}Kit`,
-        },
-    },
-    // creates npm module for adobe server side kit
-    server_cjs: {
-        input: './server-src/index.js',
-        output: {
-            ...production.output,
-            format: 'cjs',
-            file: `dist/${initialization.name}ServerSide-Kit.common.js`,
-            name: `${initialization.name}Kit`,
-        },
     },
 };
 
@@ -63,12 +44,7 @@ const testEndToEndBuild = {
 
 let selectedBuilds = [];
 if (ENVIRONMENT === 'production') {
-    selectedBuilds.push(
-        productionBuilds.iife,
-        productionBuilds.cjs,
-        productionBuilds.server_iife,
-        productionBuilds.server_cjs
-    );
+    selectedBuilds.push(productionBuilds.iife, productionBuilds.cjs);
 } else if (ENVIRONMENT === 'testEndToEnd') {
     selectedBuilds.push(testEndToEndBuild);
 }

--- a/packages/GA4Server/.gitignore
+++ b/packages/GA4Server/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+test/test-bundle.js
+test/end-to-end-testapp/compilation.js
+dist/

--- a/packages/GA4Server/package-lock.json
+++ b/packages/GA4Server/package-lock.json
@@ -1,0 +1,39 @@
+{
+  "name": "@mparticle/web-google-analytics-4-server-kit",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/estree": {
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "17.0.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.18.tgz",
+      "integrity": "sha512-eKj4f/BsN/qcculZiRSujogjvp5O/k4lOW5m35NopjZM/QwLOR075a8pJW5hD+Rtdm2DaCVPENS6KtSQnUD6BA==",
+      "dev": true
+    },
+    "rollup": {
+      "version": "1.32.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/node": "*",
+        "acorn": "^7.1.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        }
+      }
+    }
+  }
+}

--- a/packages/GA4Server/package.json
+++ b/packages/GA4Server/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@mparticle/web-google-analytics-4-server-kit",
+  "version": "1.0.0",
+  "description": "mParticle integration sdk for Google Analytics (server side)",
+  "main": "dist/GoogleAnalytics4EventForwarderServerSide-Kit.common.js",
+  "browser": "dist/GoogleAnalytics4EventForwarderServerSide-Kit.iife.js",
+  "scripts": {
+    "build": "rollup --config rollup.config.js",
+    "watch": "rollup --config rollup.config.js -w"
+  },
+  "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": "https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/tree/master/packages/GA4Server",
+  "devDependencies": {
+    "rollup": "^1.15.6"
+  }
+}

--- a/packages/GA4Server/rollup.config.js
+++ b/packages/GA4Server/rollup.config.js
@@ -1,0 +1,31 @@
+const input = 'src/GoogleAnalytics4EventForwarderServerSide.js';
+
+const outputOptions = {
+    exports: 'named',
+    strict: false,
+};
+
+const builds = {
+    // for dynamic script tag loading of adobe server side kit
+    server_iife: {
+        input,
+        output: {
+            ...outputOptions,
+            name: 'mParticleAdobe',
+            file: 'dist/GoogleAnalytics4EventForwarderServerSide-Kit.iife.js',
+            format: 'iife',
+        },
+    },
+    // creates npm module for adobe server side kit
+    server_cjs: {
+        input,
+        output: {
+            ...outputOptions,
+            name: 'mParticleAdobe',
+            file: 'dist/GoogleAnalytics4EventForwarderServerSide-Kit.common.js',
+            format: 'cjs',
+        },
+    },
+};
+
+export default [builds.server_iife, builds.server_cjs];

--- a/packages/GA4Server/src/GoogleAnalytics4EventForwarderServerSide.js
+++ b/packages/GA4Server/src/GoogleAnalytics4EventForwarderServerSide.js
@@ -18,18 +18,17 @@
 var name = 'GoogleAnalytics4EventForwarder',
     GA4MODULENUMBER = 160;
 
-var constructor = function () {
+var constructor = function() {
     var self = this;
     self.name = name;
 
     function initForwarder(forwarderSettings, service, testMode) {
-        debugger;
         mParticle._setIntegrationDelay(GA4MODULENUMBER, true);
 
         var measurementId = forwarderSettings.measurementId;
         window.dataLayer = window.dataLayer || [];
 
-        window.gtag = function () {
+        window.gtag = function() {
             window.dataLayer.push(arguments);
         };
 
@@ -44,22 +43,13 @@ var constructor = function () {
                 document.getElementsByTagName('body')[0]
             ).appendChild(clientScript);
 
-            clientScript.onload = function () {
+            clientScript.onload = function() {
                 gtag('js', new Date());
 
-                // gtag('config', measurementId, configSettings);
-
-                if (forwarderSettings.forwardRequestsServerSide === 'True') {
-                    gtag(
-                        'get',
-                        measurementId,
-                        'client_id',
-                        function (clientId) {
-                            setClientId(clientId, GA4MODULENUMBER);
-                        }
-                    );
-                    return;
-                }
+                gtag('get', measurementId, 'client_id', function(clientId) {
+                    setClientId(clientId, GA4MODULENUMBER);
+                });
+                return;
             };
         }
     }


### PR DESCRIPTION
# Summary

In order to send data server side, our server needs to send a payload with a GA4 `client_id`.  The kit must initialize the GA4 SDK, and grab the `client_id`, and set it as an integration attribute.  This is a similar paradigm to the Adobe repository, which has both client and server packages.

This GA4 server kit lives in `packages/GA4Server/src`. I also had to update a few build and set up files in the GA4Client kit folder.