### PR TITLE
chore: update forwarder name

### DIFF
--- a/packages/GA4Client/src/initialization.js
+++ b/packages/GA4Client/src/initialization.js
@@ -1,5 +1,5 @@
 var initialization = {
-    name: 'GoogleAnalytics4EventForwarder',
+    name: 'GoogleAnalytics4',
     /*  ****** Fill out initForwarder to load your SDK ******
     Note that not all arguments may apply to your SDK initialization.
     These are passed from mParticle, but leave them even if they are not being used.

--- a/packages/GA4Server/src/GoogleAnalytics4EventForwarderServerSide.js
+++ b/packages/GA4Server/src/GoogleAnalytics4EventForwarderServerSide.js
@@ -19,7 +19,7 @@
 // This GA4 server side kit loads gtag, gets the client id, and sets it as an integration attribute on the core sdk.
 // This kit does not have a `processEvent` method because no events should be sent client side.
 
-var name = 'GoogleAnalytics4EventForwarder',
+var name = 'GoogleAnalytics4',
     GA4MODULENUMBER = 160;
 
 var constructor = function() {


### PR DESCRIPTION
# Summary

We are renaming `GoogleAnalytics4EventForwarder` to `GoogleAnalytics4`.