### PR TITLE
fix: remove warning when external ID of None is selected

### DIFF
--- a/packages/GA4Client/src/common.js
+++ b/packages/GA4Client/src/common.js
@@ -86,19 +86,19 @@ Common.prototype.getUserId = function (
                         '. User not set. Please double check your implementation.'
                 );
         }
-    }
-    if (userId) {
-        if (hashUserId == 'True') {
-            userId = window.mParticle.generateHash(userId);
+        if (userId) {
+            if (hashUserId == 'True') {
+                userId = window.mParticle.generateHash(userId);
+            }
+        } else {
+            console.warn(
+                'External identity type of ' +
+                    externalUserIdentityType +
+                    ' not set on the user'
+            );
         }
-    } else {
-        console.warn(
-            'External identity type of ' +
-                externalUserIdentityType +
-                ' not set on the user'
-        );
+        return userId;
     }
-    return userId;
 };
 
 module.exports = Common;


### PR DESCRIPTION
# Summary

If `None` is selected as the external identity type, there will still be console.warn showing `External identity type of None not set on the user`.  This is misleading and looks like an error.  We move this code into the above if block to correct this.