### PR TITLE
fix: update rollup output file name for client side kit

### DIFF
--- a/packages/GA4Client/rollup.config.js
+++ b/packages/GA4Client/rollup.config.js
@@ -14,7 +14,7 @@ const productionBuilds = {
         output: {
             ...production.output,
             format: 'iife',
-            file: `dist/${initialization.name}ClientSide-Kit.iife.js`,
+            file: `dist/${initialization.name}EventForwarderClientSide-Kit.iife.js`,
             name: `${initialization.name}Kit`,
         },
         plugins: [...production.plugins],
@@ -24,7 +24,7 @@ const productionBuilds = {
         output: {
             ...production.output,
             format: 'cjs',
-            file: `dist/${initialization.name}ClientSide-Kit.common.js`,
+            file: `dist/${initialization.name}EventForwarderClientSide-Kit.common.js`,
             name: `${initialization.name}Kit`,
         },
         plugins: [...production.plugins],


### PR DESCRIPTION
# Summary

The `dist/` files for GA4Client side are based off of the name of the forwarder.  Updating this in a previous commit made the dist file change from `GoogleAnalytics4EventForwarderClientSide-Kit.iife` to `GoogleAnalytics4ClientSide-Kit.iife`, which doesn't match our database for the github url.  This PR resolves this so that the dist file continues to be named the same as before we changed the forwarder name. 