### PR TITLE
Fix import filename with GA4 filename instead of old GA kit filename

### DIFF
--- a/packages/GA4Client/package.json
+++ b/packages/GA4Client/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.1",
   "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
   "description": "mParticle integration sdk for Google Analytics",
-  "main": "dist/GoogleAnalytics4EventForwarder-Kit.common.js",
-  "browser": "dist/GoogleAnalytics4EventForwarder-Kit.iife.js",
+  "main": "dist/GoogleAnalytics4EventForwarderClientSide-Kit.common.js",
+  "browser": "dist/GoogleAnalytics4EventForwarderClientSide-Kit.iife.js",
   "scripts": {
     "test": "node test/boilerplate/test-karma.js",
     "build": "ENVIRONMENT=production rollup --config rollup.config.js",


### PR DESCRIPTION
# Summary

When we wan't to use the package we have an import error on compile.
After check we see the package.json was not update with the latest name file. 
