### PR TITLE
fix: Update main & browser values in client side package.json

### DIFF
--- a/packages/GA4Client/package.json
+++ b/packages/GA4Client/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@mparticle/web-google-analytics-4-client-kit",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "mParticle Developers <developers@mparticle.com> (https://www.mparticle.com)",
   "description": "mParticle integration sdk for Google Analytics",
-  "main": "dist/GoogleAnalytics4EventForwarder-Kit.common.js",
-  "browser": "dist/GoogleAnalytics4EventForwarder-Kit.iife.js",
+  "main": "dist/GoogleAnalytics4EventForwarderClientSide-Kit.common.js",
+  "browser": "dist/GoogleAnalytics4EventForwarderClientSide-Kit.iife.js",
   "scripts": {
     "test": "node test/boilerplate/test-karma.js",
     "build": "ENVIRONMENT=production rollup --config rollup.config.js",


### PR DESCRIPTION
# Summary

The reference to `main` and `browser` is incorrect in the `client/package.json` file and is resulting in users being unable to find the module when self hosting.  Updating this fixes the issue.  The reason for this is because we originally did not separate this to be client side and server side.  After we developed the server side kit in this repo, `serverside/package.json' correctly refers to the right dist/ files, but I did not go back to update the client side links.

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-4201
