### PR TITLE
fix: Add Event Attributes to Pageview Event

### DIFF
--- a/packages/GA4Client/src/event-handler.js
+++ b/packages/GA4Client/src/event-handler.js
@@ -14,21 +14,28 @@ EventHandler.prototype.logPageView = function (event) {
     var TITLE = 'Google.Title';
     var LOCATION = 'Google.Location';
     var pageTitle, pageLocation;
-    if (event.CustomFlags.hasOwnProperty(TITLE)) {
+
+    if (event.CustomFlags && event.CustomFlags.hasOwnProperty(TITLE)) {
         pageTitle = event.CustomFlags[TITLE];
     } else {
         pageTitle = document.title;
     }
 
-    if (event.CustomFlags.hasOwnProperty(LOCATION)) {
+    if (event.CustomFlags && event.CustomFlags.hasOwnProperty(LOCATION)) {
         pageLocation = event.CustomFlags[LOCATION];
     } else {
         pageLocation = location.href;
     }
-    gtag('event', 'page_view', {
-        page_title: pageTitle,
-        page_location: pageLocation,
-    });
+
+    var eventAttributes = this.common.mergeObjects(
+        {
+            page_title: pageTitle,
+            page_location: pageLocation,
+        },
+        event.EventAttributes
+    );
+
+    gtag('event', 'page_view', eventAttributes);
 
     return true;
 };

--- a/packages/GA4Client/test/index.html
+++ b/packages/GA4Client/test/index.html
@@ -20,7 +20,7 @@
         };
 
     </script>
-    <script src="../dist/GoogleAnalytics4EventForwarder-Kit.iife.js"></script>
+    <script src="../dist/GoogleAnalytics4EventForwarderClientSide-Kit.iife.js"></script>
 
     <script>mocha.setup('bdd')</script>
 

--- a/packages/GA4Client/test/tests.js
+++ b/packages/GA4Client/test/tests.js
@@ -1337,7 +1337,27 @@ describe('Google Analytics 4 Event', function () {
                 done();
             });
 
-            it('should log page view', function (done) {
+            it('should log page view ', function (done) {
+                mParticle.forwarder.process({
+                    EventDataType: MessageType.PageView,
+                    EventName: 'test name',
+                    EventAttributes: {},
+                });
+
+                var result = [
+                    'event',
+                    'page_view',
+                    {
+                        page_title: 'Mocha Tests',
+                        page_location: location.href,
+                    },
+                ];
+                window.dataLayer[0].should.eql(result);
+
+                done();
+            });
+
+            it('should log page view with event attributes', function (done) {
                 mParticle.forwarder.process({
                     EventDataType: MessageType.PageView,
                     EventName: 'test name',
@@ -1354,7 +1374,12 @@ describe('Google Analytics 4 Event', function () {
                 var result = [
                     'event',
                     'page_view',
-                    { page_title: 'Foo Page Title', page_location: '/foo' },
+                    {
+                        page_title: 'Foo Page Title',
+                        page_location: '/foo',
+                        eventKey1: 'test1',
+                        eventKey2: 'test2',
+                    },
                 ];
                 window.dataLayer[0].should.eql(result);
 


### PR DESCRIPTION
## Summary
- Adding Event Attributes to Page View Events so they behave more consistent with other events and user expectations.

## Testing Plan
- Manual and Automated Tests

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4554
