### PR TITLE
fix: Correct custom flags for title and location

### DIFF
--- a/packages/GA4Client/src/event-handler.js
+++ b/packages/GA4Client/src/event-handler.js
@@ -14,16 +14,24 @@ EventHandler.prototype.logPageView = function (event) {
     var TITLE = 'GA4.Title';
     var LOCATION = 'GA4.Location';
 
+    // These are being included for backwards compatibility from the previous Google Analytics custom flags
+    var GOOGLE_TITLE = 'Google.Title';
+    var GOOGLE_LOCATION = 'Google.Location';
+
     var pageTitle, pageLocation;
 
     if (event.CustomFlags && event.CustomFlags.hasOwnProperty(TITLE)) {
         pageTitle = event.CustomFlags[TITLE];
+    } else if (event.CustomFlags.hasOwnProperty(GOOGLE_TITLE)) {
+        pageTitle = event.CustomFlags[GOOGLE_TITLE];
     } else {
         pageTitle = document.title;
     }
 
     if (event.CustomFlags && event.CustomFlags.hasOwnProperty(LOCATION)) {
         pageLocation = event.CustomFlags[LOCATION];
+    } else if (event.CustomFlags.hasOwnProperty(GOOGLE_LOCATION)) {
+        pageLocation = event.CustomFlags[GOOGLE_LOCATION];
     } else {
         pageLocation = location.href;
     }

--- a/packages/GA4Client/src/event-handler.js
+++ b/packages/GA4Client/src/event-handler.js
@@ -14,7 +14,7 @@ EventHandler.prototype.logPageView = function (event) {
     var TITLE = 'GA4.Title';
     var LOCATION = 'GA4.Location';
 
-    // These are being included for backwards compatibility from the previous Google Analytics custom flags
+    // These are being included for backwards compatibility from the legacy Google Analytics custom flags
     var LEGACY_GA_TITLE = 'Google.Title';
     var LEGACY_GA_LOCATION = 'Google.Location';
 

--- a/packages/GA4Client/src/event-handler.js
+++ b/packages/GA4Client/src/event-handler.js
@@ -15,23 +15,23 @@ EventHandler.prototype.logPageView = function (event) {
     var LOCATION = 'GA4.Location';
 
     // These are being included for backwards compatibility from the previous Google Analytics custom flags
-    var GOOGLE_TITLE = 'Google.Title';
-    var GOOGLE_LOCATION = 'Google.Location';
+    var LEGACY_GA_TITLE = 'Google.Title';
+    var LEGACY_GA_LOCATION = 'Google.Location';
 
     var pageTitle, pageLocation;
 
     if (event.CustomFlags && event.CustomFlags.hasOwnProperty(TITLE)) {
         pageTitle = event.CustomFlags[TITLE];
-    } else if (event.CustomFlags.hasOwnProperty(GOOGLE_TITLE)) {
-        pageTitle = event.CustomFlags[GOOGLE_TITLE];
+    } else if (event.CustomFlags.hasOwnProperty(LEGACY_GA_TITLE)) {
+        pageTitle = event.CustomFlags[LEGACY_GA_TITLE];
     } else {
         pageTitle = document.title;
     }
 
     if (event.CustomFlags && event.CustomFlags.hasOwnProperty(LOCATION)) {
         pageLocation = event.CustomFlags[LOCATION];
-    } else if (event.CustomFlags.hasOwnProperty(GOOGLE_LOCATION)) {
-        pageLocation = event.CustomFlags[GOOGLE_LOCATION];
+    } else if (event.CustomFlags.hasOwnProperty(LEGACY_GA_LOCATION)) {
+        pageLocation = event.CustomFlags[LEGACY_GA_LOCATION];
     } else {
         pageLocation = location.href;
     }

--- a/packages/GA4Client/src/event-handler.js
+++ b/packages/GA4Client/src/event-handler.js
@@ -11,8 +11,9 @@ EventHandler.prototype.logError = function () {
 };
 
 EventHandler.prototype.logPageView = function (event) {
-    var TITLE = 'Google.Title';
-    var LOCATION = 'Google.Location';
+    var TITLE = 'GA4.Title';
+    var LOCATION = 'GA4.Location';
+
     var pageTitle, pageLocation;
 
     if (event.CustomFlags && event.CustomFlags.hasOwnProperty(TITLE)) {

--- a/packages/GA4Client/src/event-handler.js
+++ b/packages/GA4Client/src/event-handler.js
@@ -18,22 +18,21 @@ EventHandler.prototype.logPageView = function (event) {
     var LEGACY_GA_TITLE = 'Google.Title';
     var LEGACY_GA_LOCATION = 'Google.Location';
 
-    var pageTitle, pageLocation;
-
-    if (event.CustomFlags && event.CustomFlags.hasOwnProperty(TITLE)) {
-        pageTitle = event.CustomFlags[TITLE];
-    } else if (event.CustomFlags.hasOwnProperty(LEGACY_GA_TITLE)) {
-        pageTitle = event.CustomFlags[LEGACY_GA_TITLE];
-    } else {
+    var pageLocation = location.href,
         pageTitle = document.title;
-    }
 
-    if (event.CustomFlags && event.CustomFlags.hasOwnProperty(LOCATION)) {
-        pageLocation = event.CustomFlags[LOCATION];
-    } else if (event.CustomFlags.hasOwnProperty(LEGACY_GA_LOCATION)) {
-        pageLocation = event.CustomFlags[LEGACY_GA_LOCATION];
-    } else {
-        pageLocation = location.href;
+    if (event.CustomFlags) {
+        if (event.CustomFlags.hasOwnProperty(TITLE)) {
+            pageTitle = event.CustomFlags[TITLE];
+        } else if (event.CustomFlags.hasOwnProperty(LEGACY_GA_TITLE)) {
+            pageTitle = event.CustomFlags[LEGACY_GA_TITLE];
+        }
+
+        if (event.CustomFlags.hasOwnProperty(LOCATION)) {
+            pageLocation = event.CustomFlags[LOCATION];
+        } else if (event.CustomFlags.hasOwnProperty(LEGACY_GA_LOCATION)) {
+            pageLocation = event.CustomFlags[LEGACY_GA_LOCATION];
+        }
     }
 
     var eventAttributes = this.common.mergeObjects(

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -1358,7 +1358,7 @@ describe('Google Analytics 4 Event', function () {
             });
             // This test exist for backwards compatibility of custom flags carried
             // over from legacy Google Analytics - Google.Title and Google.Location
-            it.only('should log page view with legacy GA custom flags', function (done) {
+            it('should log page view with legacy GA custom flags', function (done) {
                 mParticle.forwarder.process({
                     EventDataType: MessageType.PageView,
                     EventName: 'test name',

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -1350,17 +1350,40 @@ describe('Google Analytics 4 Event', function () {
                 var result = [
                     'event',
                     'page_view',
-                    {
-                        page_title: 'Mocha Tests',
-                        page_location: location.href,
-                    },
+                    { page_title: 'Foo Page Title', page_location: '/foo' },
                 ];
                 window.dataLayer[0].should.eql(result);
 
                 done();
             });
+            // This test exist for backwards compatibility of custom flags carried
+            // over from legacy Google Analytics - Google.Title and Google.Location
+            it.only('should log page view with legacy GA custom flags', function (done) {
+                mParticle.forwarder.process({
+                    EventDataType: MessageType.PageView,
+                    EventName: 'test name',
+                    EventAttributes: {
+                        eventKey1: 'test1',
+                        eventKey2: 'test2',
+                    },
+                    CustomFlags: {
+                        'Google.Title': 'Foo Page Title',
+                        'Google.Location': '/foo',
+                    }
+                });
+                var result = [
+                    'event',
+                    'page_view',
+                    {
+                        page_title: 'Mocha Tests',
+                        page_location: location.href,
+                    },
+                ];
 
-            it('should log page view with event attributes', function (done) {
+                window.dataLayer[0].should.eql(result);
+            });
+
+            it('should log page view with new GA custom flags', function (done) {
                 mParticle.forwarder.process({
                     EventDataType: MessageType.PageView,
                     EventName: 'test name',

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -1345,32 +1345,9 @@ describe('Google Analytics 4 Event', function () {
                     EventDataType: MessageType.PageView,
                     EventName: 'test name',
                     EventAttributes: {},
+                    CustomFlags: {},
                 });
 
-                var result = [
-                    'event',
-                    'page_view',
-                    { page_title: 'Foo Page Title', page_location: '/foo' },
-                ];
-                window.dataLayer[0].should.eql(result);
-
-                done();
-            });
-            // This test exist for backwards compatibility of custom flags carried
-            // over from legacy Google Analytics - Google.Title and Google.Location
-            it('should log page view with legacy GA custom flags', function (done) {
-                mParticle.forwarder.process({
-                    EventDataType: MessageType.PageView,
-                    EventName: 'test name',
-                    EventAttributes: {
-                        eventKey1: 'test1',
-                        eventKey2: 'test2',
-                    },
-                    CustomFlags: {
-                        'Google.Title': 'Foo Page Title',
-                        'Google.Location': '/foo',
-                    }
-                });
                 var result = [
                     'event',
                     'page_view',
@@ -1379,11 +1356,12 @@ describe('Google Analytics 4 Event', function () {
                         page_location: location.href,
                     },
                 ];
-
                 window.dataLayer[0].should.eql(result);
+
+                done();
             });
 
-            it('should log page view with new GA custom flags', function (done) {
+            it('should log page view with event attributes', function (done) {
                 mParticle.forwarder.process({
                     EventDataType: MessageType.PageView,
                     EventName: 'test name',
@@ -1405,6 +1383,55 @@ describe('Google Analytics 4 Event', function () {
                         page_location: '/foo',
                         eventKey1: 'test1',
                         eventKey2: 'test2',
+                    },
+                ];
+                window.dataLayer[0].should.eql(result);
+
+                done();
+            });
+
+            // This test exist for backwards compatibility of custom flags carried
+            // over from legacy Google Analytics - Google.Title and Google.Location
+            it('should log page view with legacy GA custom flags', function (done) {
+                mParticle.forwarder.process({
+                    EventDataType: MessageType.PageView,
+                    EventName: 'test name',
+                    EventAttributes: {},
+                    CustomFlags: {
+                        'Google.Title': 'Foo Page Title',
+                        'Google.Location': '/foo',
+                    },
+                });
+                var result = [
+                    'event',
+                    'page_view',
+                    {
+                        page_title: 'Foo Page Title',
+                        page_location: '/foo',
+                    },
+                ];
+
+                window.dataLayer[0].should.eql(result);
+                done();
+            });
+
+            it('should log page view with new GA custom flags', function (done) {
+                mParticle.forwarder.process({
+                    EventDataType: MessageType.PageView,
+                    EventName: 'test name',
+                    EventAttributes: {},
+                    CustomFlags: {
+                        'GA4.Title': 'Foo Page Title',
+                        'GA4.Location': '/foo',
+                    },
+                });
+
+                var result = [
+                    'event',
+                    'page_view',
+                    {
+                        page_title: 'Foo Page Title',
+                        page_location: '/foo',
                     },
                 ];
                 window.dataLayer[0].should.eql(result);

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -1369,8 +1369,8 @@ describe('Google Analytics 4 Event', function () {
                         eventKey2: 'test2',
                     },
                     CustomFlags: {
-                        'Google.Title': 'Foo Page Title',
-                        'Google.Location': '/foo',
+                        'GA4.Title': 'Foo Page Title',
+                        'GA4.Location': '/foo',
                     },
                 });
 


### PR DESCRIPTION
## Summary
Updaing the custom flags for `page` and `location` to be `GA4.Page` and `GA4.Location`.  We are keeping backwards compatibility in case any customers migrated to GA4 and kept their legacy GA implementation, which used `Google.Location` and `Google.Page`.

## Testing Plan
* Unit tests
* Manually saw in the Google UI that custom flags are working, page and location both sent in chrome network tab.

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-4966
