### PR TITLE
fix: Check if Event Attributes are empty before truncating

### DIFF
--- a/packages/GA4Client/src/common.js
+++ b/packages/GA4Client/src/common.js
@@ -14,6 +14,10 @@ function truncateString(string, limit) {
         : string;
 }
 
+function isEmpty(value) {
+    return value == null || !(Object.keys(value) || value).length;
+}
+
 function Common() {}
 
 Common.prototype.forwarderSettings = null;
@@ -37,11 +41,13 @@ Common.prototype.truncateAttributes = function (
 ) {
     var truncatedAttributes = {};
 
-    Object.keys(attributes).forEach(function (attribute) {
-        var key = truncateString(attribute, keyLimit);
-        var val = truncateString(attributes[attribute], valueLimit);
-        truncatedAttributes[key] = val;
-    });
+    if (!isEmpty(attributes)) {
+        Object.keys(attributes).forEach(function (attribute) {
+            var key = truncateString(attribute, keyLimit);
+            var val = truncateString(attributes[attribute], valueLimit);
+            truncatedAttributes[key] = val;
+        });
+    }
 
     return truncatedAttributes;
 };

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -1321,6 +1321,33 @@ describe('Google Analytics 4 Event', function () {
         });
 
         describe('event mapping', function () {
+            it('should log the event without attributes', function (done) {
+                mParticle.forwarder.process({
+                    EventDataType: MessageType.PageEvent,
+                    EventCategory: EventType.Navigation,
+                    EventName: 'Unmapped Event Name',
+                });
+
+                var result = ['event', 'Unmapped Event Name', {}];
+                window.dataLayer[0].should.eql(result);
+
+                done();
+            });
+
+            it('should log the event attributes are null', function (done) {
+                mParticle.forwarder.process({
+                    EventDataType: MessageType.PageEvent,
+                    EventCategory: EventType.Navigation,
+                    EventName: 'Unmapped Event Name',
+                    EventAttributes: null,
+                });
+
+                var result = ['event', 'Unmapped Event Name', {}];
+                window.dataLayer[0].should.eql(result);
+
+                done();
+            });
+
             it('should log the event name and event attributes of the page event', function (done) {
                 mParticle.forwarder.process({
                     EventDataType: MessageType.PageEvent,

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -1334,7 +1334,7 @@ describe('Google Analytics 4 Event', function () {
                 done();
             });
 
-            it('should log the event attributes are null', function (done) {
+            it('should log the event when attributes are null', function (done) {
                 mParticle.forwarder.process({
                     EventDataType: MessageType.PageEvent,
                     EventCategory: EventType.Navigation,


### PR DESCRIPTION
## Summary
- If event attributes are set to `null`, the kit will throw an exception. We should be defensive and check to make sure the attributes are not actually empty or set to `null`.

## Testing Plan
- Run automated tests and use sample app to verify

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-5063
