### PR TITLE
feat: Capture Client ID on Client Side Forwarding

### DIFF
--- a/packages/GA4Client/package-lock.json
+++ b/packages/GA4Client/package-lock.json
@@ -9,7 +9,8 @@
             "version": "1.0.6",
             "license": "Apache-2.0",
             "dependencies": {
-                "@mparticle/web-sdk": "^2.12.2"
+                "@mparticle/web-sdk": "^2.12.2",
+                "sinon": "^15.1.0"
             },
             "devDependencies": {
                 "@mparticle/web-kit-wrapper": "^1.0.5",
@@ -705,6 +706,45 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/@sinonjs/commons": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+            "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+            "dependencies": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "node_modules/@sinonjs/fake-timers": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.2.0.tgz",
+            "integrity": "sha512-OPwQlEdg40HAj5KNF8WW6q2KG4Z+cBCZb3m4ninfTZKaBmbIJodviQsDBoYMPHkOyJJMHnOJo5j2+LKDOhOACg==",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.0"
+            }
+        },
+        "node_modules/@sinonjs/samsam": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+            "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
+            "dependencies": {
+                "@sinonjs/commons": "^2.0.0",
+                "lodash.get": "^4.4.2",
+                "type-detect": "^4.0.8"
+            }
+        },
+        "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+            "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+            "dependencies": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "node_modules/@sinonjs/text-encoding": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+            "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ=="
         },
         "node_modules/@tootallnate/once": {
             "version": "1.1.2",
@@ -3963,7 +4003,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -4865,6 +4904,11 @@
                 "node": "*"
             }
         },
+        "node_modules/just-extend": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+            "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
+        },
         "node_modules/karma": {
             "version": "5.2.3",
             "resolved": "https://registry.npmjs.org/karma/-/karma-5.2.3.tgz",
@@ -5050,6 +5094,11 @@
             "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
             "dev": true,
             "peer": true
+        },
+        "node_modules/lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
         },
         "node_modules/lodash.ismatch": {
             "version": "4.4.0",
@@ -5792,6 +5841,39 @@
             "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
             "dev": true,
             "peer": true
+        },
+        "node_modules/nise": {
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
+            "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
+            "dependencies": {
+                "@sinonjs/commons": "^2.0.0",
+                "@sinonjs/fake-timers": "^10.0.2",
+                "@sinonjs/text-encoding": "^0.7.1",
+                "just-extend": "^4.0.2",
+                "path-to-regexp": "^1.7.0"
+            }
+        },
+        "node_modules/nise/node_modules/@sinonjs/commons": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+            "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+            "dependencies": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "node_modules/nise/node_modules/isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+        },
+        "node_modules/nise/node_modules/path-to-regexp": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+            "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+            "dependencies": {
+                "isarray": "0.0.1"
+            }
         },
         "node_modules/node-emoji": {
             "version": "1.11.0",
@@ -10953,6 +11035,31 @@
                 }
             ]
         },
+        "node_modules/sinon": {
+            "version": "15.1.0",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.1.0.tgz",
+            "integrity": "sha512-cS5FgpDdE9/zx7no8bxROHymSlPLZzq0ChbbLk1DrxBfc+eTeBK3y8nIL+nu/0QeYydhhbLIr7ecHJpywjQaoQ==",
+            "dependencies": {
+                "@sinonjs/commons": "^3.0.0",
+                "@sinonjs/fake-timers": "^10.2.0",
+                "@sinonjs/samsam": "^8.0.0",
+                "diff": "^5.1.0",
+                "nise": "^5.1.4",
+                "supports-color": "^7.2.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/sinon"
+            }
+        },
+        "node_modules/sinon/node_modules/diff": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+            "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
         "node_modules/slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -11631,7 +11738,6 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -12029,7 +12135,6 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
             "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -13412,6 +13517,47 @@
                     "peer": true
                 }
             }
+        },
+        "@sinonjs/commons": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+            "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+            "requires": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "@sinonjs/fake-timers": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.2.0.tgz",
+            "integrity": "sha512-OPwQlEdg40HAj5KNF8WW6q2KG4Z+cBCZb3m4ninfTZKaBmbIJodviQsDBoYMPHkOyJJMHnOJo5j2+LKDOhOACg==",
+            "requires": {
+                "@sinonjs/commons": "^3.0.0"
+            }
+        },
+        "@sinonjs/samsam": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+            "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
+            "requires": {
+                "@sinonjs/commons": "^2.0.0",
+                "lodash.get": "^4.4.2",
+                "type-detect": "^4.0.8"
+            },
+            "dependencies": {
+                "@sinonjs/commons": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+                    "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+                    "requires": {
+                        "type-detect": "4.0.8"
+                    }
+                }
+            }
+        },
+        "@sinonjs/text-encoding": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+            "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ=="
         },
         "@tootallnate/once": {
             "version": "1.1.2",
@@ -16075,8 +16221,7 @@
         "has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "has-symbols": {
             "version": "1.0.3",
@@ -16773,6 +16918,11 @@
                 "through": ">=2.2.7 <3"
             }
         },
+        "just-extend": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+            "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg=="
+        },
         "karma": {
             "version": "5.2.3",
             "resolved": "https://registry.npmjs.org/karma/-/karma-5.2.3.tgz",
@@ -16935,6 +17085,11 @@
             "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
             "dev": true,
             "peer": true
+        },
+        "lodash.get": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+            "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
         },
         "lodash.ismatch": {
             "version": "4.4.0",
@@ -17539,6 +17694,41 @@
             "integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
             "dev": true,
             "peer": true
+        },
+        "nise": {
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
+            "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
+            "requires": {
+                "@sinonjs/commons": "^2.0.0",
+                "@sinonjs/fake-timers": "^10.0.2",
+                "@sinonjs/text-encoding": "^0.7.1",
+                "just-extend": "^4.0.2",
+                "path-to-regexp": "^1.7.0"
+            },
+            "dependencies": {
+                "@sinonjs/commons": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+                    "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+                    "requires": {
+                        "type-detect": "4.0.8"
+                    }
+                },
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+                },
+                "path-to-regexp": {
+                    "version": "1.8.0",
+                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+                    "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+                    "requires": {
+                        "isarray": "0.0.1"
+                    }
+                }
+            }
         },
         "node-emoji": {
             "version": "1.11.0",
@@ -21421,6 +21611,26 @@
             "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
             "dev": true
         },
+        "sinon": {
+            "version": "15.1.0",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.1.0.tgz",
+            "integrity": "sha512-cS5FgpDdE9/zx7no8bxROHymSlPLZzq0ChbbLk1DrxBfc+eTeBK3y8nIL+nu/0QeYydhhbLIr7ecHJpywjQaoQ==",
+            "requires": {
+                "@sinonjs/commons": "^3.0.0",
+                "@sinonjs/fake-timers": "^10.2.0",
+                "@sinonjs/samsam": "^8.0.0",
+                "diff": "^5.1.0",
+                "nise": "^5.1.4",
+                "supports-color": "^7.2.0"
+            },
+            "dependencies": {
+                "diff": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+                    "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw=="
+                }
+            }
+        },
         "slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -22014,7 +22224,6 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
             "requires": {
                 "has-flag": "^4.0.0"
             }
@@ -22330,8 +22539,7 @@
         "type-detect": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-            "dev": true
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
         },
         "type-fest": {
             "version": "0.20.2",

--- a/packages/GA4Client/package.json
+++ b/packages/GA4Client/package.json
@@ -44,7 +44,8 @@
         "watchify": "^3.11.0"
     },
     "dependencies": {
-        "@mparticle/web-sdk": "^2.12.2"
+        "@mparticle/web-sdk": "^2.12.2",
+        "sinon": "^15.1.0"
     },
     "license": "Apache-2.0"
 }

--- a/packages/GA4Client/package.json
+++ b/packages/GA4Client/package.json
@@ -25,27 +25,27 @@
         "@semantic-release/changelog": "^5.0.1",
         "@semantic-release/exec": "^5.0.0",
         "@semantic-release/git": "^9.0.0",
-        "mocha": "^5.2.0",
         "chai": "^4.2.0",
+        "eslint": "^7.25.0",
+        "eslint-config-prettier": "8.3.0",
+        "eslint-plugin-prettier": "3.4.1",
         "karma": "^5.1.0",
         "karma-chai": "^0.1.0",
         "karma-chrome-launcher": "^3.1.0",
         "karma-firefox-launcher": "^1.3.0",
         "karma-mocha": "^2.0.1",
+        "mocha": "^5.2.0",
+        "prettier": "^2.4.1",
         "rollup": "^1.15.6",
         "rollup-plugin-commonjs": "^10.0.0",
         "rollup-plugin-node-resolve": "^5.0.3",
         "shelljs": "0.8.3",
-        "eslint": "^7.25.0",
-        "eslint-config-prettier": "8.3.0",
-        "eslint-plugin-prettier": "3.4.1",
         "should": "13.2.3",
-        "prettier": "^2.4.1",
+        "sinon": "^15.1.0",
         "watchify": "^3.11.0"
     },
     "dependencies": {
-        "@mparticle/web-sdk": "^2.12.2",
-        "sinon": "^15.1.0"
+        "@mparticle/web-sdk": "^2.12.2"
     },
     "license": "Apache-2.0"
 }

--- a/packages/GA4Client/src/initialization.js
+++ b/packages/GA4Client/src/initialization.js
@@ -1,5 +1,6 @@
 var initialization = {
     name: 'GoogleAnalytics4',
+    moduleId: '160',
     /*  ****** Fill out initForwarder to load your SDK ******
     Note that not all arguments may apply to your SDK initialization.
     These are passed from mParticle, but leave them even if they are not being used.
@@ -46,6 +47,10 @@ var initialization = {
         }
         gtag('config', measurementId, configSettings);
 
+        gtag('get', measurementId, 'client_id', function (clientId) {
+            setClientId(clientId, this.moduleId);
+        });
+
         if (!testMode) {
             var clientScript = document.createElement('script');
             clientScript.type = 'text/javascript';
@@ -73,5 +78,13 @@ var initialization = {
         return isInitialized;
     },
 };
+
+function setClientId(clientId, moduleId) {
+    var GA4CLIENTID = 'client_id';
+    var ga4IntegrationAttributes = {};
+    ga4IntegrationAttributes[GA4CLIENTID] = clientId;
+    mParticle.setIntegrationAttribute(moduleId, ga4IntegrationAttributes);
+    mParticle._setIntegrationDelay(moduleId, false);
+}
 
 module.exports = initialization;

--- a/packages/GA4Client/src/initialization.js
+++ b/packages/GA4Client/src/initialization.js
@@ -1,6 +1,6 @@
 var initialization = {
     name: 'GoogleAnalytics4',
-    moduleId: '160',
+    moduleId: 160,
     /*  ****** Fill out initForwarder to load your SDK ******
     Note that not all arguments may apply to your SDK initialization.
     These are passed from mParticle, but leave them even if they are not being used.
@@ -19,6 +19,8 @@ var initialization = {
         isInitialized,
         common
     ) {
+        mParticle._setIntegrationDelay(this.moduleId, true);
+
         common.forwarderSettings = forwarderSettings;
         var measurementId = forwarderSettings.measurementId;
         var userIdType = forwarderSettings.externalUserIdentityType;
@@ -48,7 +50,7 @@ var initialization = {
         gtag('config', measurementId, configSettings);
 
         gtag('get', measurementId, 'client_id', function (clientId) {
-            setClientId(clientId, this.moduleId);
+            setClientId(clientId, initialization.moduleId);
         });
 
         if (!testMode) {

--- a/packages/GA4Client/src/initialization.js
+++ b/packages/GA4Client/src/initialization.js
@@ -50,6 +50,7 @@ var initialization = {
         gtag('config', measurementId, configSettings);
 
         gtag('get', measurementId, 'client_id', function (clientId) {
+            // TODO: Does GTAG Hash the clientId somehow?
             setClientId(clientId, initialization.moduleId);
         });
 
@@ -85,8 +86,11 @@ function setClientId(clientId, moduleId) {
     var GA4CLIENTID = 'client_id';
     var ga4IntegrationAttributes = {};
     ga4IntegrationAttributes[GA4CLIENTID] = clientId;
-    mParticle.setIntegrationAttribute(moduleId, ga4IntegrationAttributes);
-    mParticle._setIntegrationDelay(moduleId, false);
+    window.mParticle.setIntegrationAttribute(
+        moduleId,
+        ga4IntegrationAttributes
+    );
+    window.mParticle._setIntegrationDelay(moduleId, false);
 }
 
 module.exports = initialization;

--- a/packages/GA4Client/src/initialization.js
+++ b/packages/GA4Client/src/initialization.js
@@ -50,7 +50,6 @@ var initialization = {
         gtag('config', measurementId, configSettings);
 
         gtag('get', measurementId, 'client_id', function (clientId) {
-            // TODO: Does GTAG Hash the clientId somehow?
             setClientId(clientId, initialization.moduleId);
         });
 

--- a/packages/GA4Client/test/index.html
+++ b/packages/GA4Client/test/index.html
@@ -9,6 +9,7 @@
 
         <script src="../node_modules/mocha/mocha.js"></script>
         <script src="../node_modules/should/should.js"></script>
+        <script src="../node_modules/sinon/pkg/sinon.js"></script>
         <script src="./lib/mockhttprequest.js"></script>
         <script src="../node_modules/@mparticle/web-sdk/dist/mparticle.js"></script>
 

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -189,7 +189,6 @@ describe('Google Analytics 4 Event', function () {
 
         it('should initialize with a measurement id as `client_id`', function (done) {
             window.mockGA4EventForwarder = new mockGA4EventForwarder();
-            // Include any specific settings that is required for initializing your SDK here
             mParticle.forwarder.init(kitSettings, reportService.cb, true);
 
             window.gtag.should.be.ok();
@@ -227,7 +226,7 @@ describe('Google Analytics 4 Event', function () {
             // Set Integration Delay should be called twice upon init
             // First, as true, then false after client ID is registered
             mPStub._setIntegrationDelay.getCall(0).calledWith(160, true);
-            mPStub._setIntegrationDelay.getCall(1).calledWith(160, true);
+            mPStub._setIntegrationDelay.getCall(1).calledWith(160, false);
 
             sandbox.restore();
             done();

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -184,6 +184,22 @@ describe('Google Analytics 4 Event', function () {
 
             done();
         });
+
+        it('should initialize with a measurement id as `client_id`', function (done) {
+            (typeof window.gtag === 'undefined').should.be.true();
+            (typeof window.dataLayer === 'undefined').should.be.true();
+            window.mockGA4EventForwarder = new mockGA4EventForwarder();
+            // Include any specific settings that is required for initializing your SDK here
+            mParticle.forwarder.init(kitSettings, reportService.cb, true);
+
+            window.gtag.should.be.ok();
+            window.dataLayer.should.be.ok();
+            window.dataLayer[2][0].should.eql('get');
+            window.dataLayer[2][1].should.eql('testMeasurementId');
+            window.dataLayer[2][2].should.eql('client_id');
+
+            done();
+        });
     });
     describe('forwarder mapping', function () {
         beforeEach(function () {

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -216,9 +216,14 @@ describe('Google Analytics 4 Event', function () {
 
             mParticle.forwarder.init(kitSettings, reportService.cb, true);
 
-            // GTAG will fire an async get request so we are simply
-            // verifying that measurementID/clientID makes it into
-            // mParticle.setIntegrationAttribute via gtag
+            // GTAG will normally trigger every callback in the DataLayer
+            // asynchronously. However, since we are mocking GTAG within our tests,
+            // we need to manually trigger the callback directly to verify that
+            // mParticle.setIntegrationAttribute is eventually called with
+            // measurementID/clientID via GTAG.
+            // The specific 'get' request is index 2, and the callback is
+            // index 3. We are manually passing a string into the callback
+            // as GTAG seems to hash the id internally.
             dataLayer[2][3]('testMeasurementId');
 
             // Verify that data later triggers setClientId

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -220,15 +220,15 @@ describe('Google Analytics 4 Event', function () {
             // asynchronously. However, since we are mocking GTAG within our tests,
             // we need to manually trigger the callback directly to verify that
             // mParticle.setIntegrationAttribute is eventually called with
-            // measurementID/clientID via GTAG.
+            // clientID via GTAG.
             // The specific 'get' request is index 2, and the callback is
             // index 3. We are manually passing a string into the callback
             // as GTAG seems to hash the id internally.
-            dataLayer[2][3]('testMeasurementId');
+            dataLayer[2][3]('test-client-id');
 
             // Verify that data later triggers setClientId
             mPStub.setIntegrationAttribute.calledWith(160, {
-                client_id: 'testMeasurementId',
+                client_id: 'test-client-id',
             });
 
             // Set Integration Delay should be called twice upon init

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -1,4 +1,7 @@
-var sinon = require('sinon');
+// If we are testing this in a browser runner, sinon is loaded via script tag
+if (typeof require !== 'undefined') {
+    var sinon = require('sinon');
+}
 
 /* eslint-disable no-undef*/
 describe('Google Analytics 4 Event', function () {


### PR DESCRIPTION
## Summary
- Capture measurement id on GA4 Client package and send to dataLayer as `client_id`.

## Testing Plan
- Manually test using sample app set for GA4 Client implementation
- Verify dataLayer contains `['get', 'testMeasurementId', 'client_id']` after init.
- Verify measurement ID is in `mParticle._Store.integrationAttributes`.

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-5415
