### PR TITLE
fix: Flatten product.Attributes to be on the product level

### DIFF
--- a/packages/GA4Client/src/commerce-handler.js
+++ b/packages/GA4Client/src/commerce-handler.js
@@ -245,32 +245,43 @@ function toUnderscore(string) {
         .toLowerCase();
 }
 
-function parseProduct(_product) {
-    var product = {};
+function parseProduct(product) {
+    var productWithAllAttributes = {};
 
-    for (var key in _product) {
-        switch (key) {
-            case 'Sku':
-                product.item_id = _product.Sku;
-                break;
-            case 'Name':
-                product.item_name = _product.Name;
-                break;
-            case 'Brand':
-                product.item_brand = _product.Brand;
-                break;
-            case 'Category':
-                product.item_category = _product.Category;
-                break;
-            case 'Variant':
-                product.item_variant = _product.Variant;
-                break;
-            default:
-                product[toUnderscore(key)] = _product[key];
+    // 1. Move key/value pairs from product.Attributes to be at the same level
+    // as all keys in product
+    if (product.Attributes) {
+        for (var prodAttr in product.Attributes) {
+            productWithAllAttributes[prodAttr] = product.Attributes[prodAttr];
         }
     }
 
-    return product;
+    // 2. Copy key/value pairs in product
+    for (var key in product) {
+        switch (key) {
+            case 'Sku':
+                productWithAllAttributes.item_id = product.Sku;
+                break;
+            case 'Name':
+                productWithAllAttributes.item_name = product.Name;
+                break;
+            case 'Brand':
+                productWithAllAttributes.item_brand = product.Brand;
+                break;
+            case 'Category':
+                productWithAllAttributes.item_category = product.Category;
+                break;
+            case 'Variant':
+                productWithAllAttributes.item_variant = product.Variant;
+                break;
+            case 'Attributes':
+                break;
+            default:
+                productWithAllAttributes[toUnderscore(key)] = product[key];
+        }
+    }
+
+    return productWithAllAttributes;
 }
 
 function parsePromotion(_promotion) {

--- a/packages/GA4Client/src/initialization.js
+++ b/packages/GA4Client/src/initialization.js
@@ -25,6 +25,7 @@ var initialization = {
         var measurementId = forwarderSettings.measurementId;
         var userIdType = forwarderSettings.externalUserIdentityType;
         var hashUserId = forwarderSettings.hashUserId;
+
         var configSettings = {
             send_page_view: forwarderSettings.enablePageView === 'True',
         };

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -278,10 +278,6 @@ describe('Google Analytics 4 Event', function () {
                         value: 100,
                         items: [
                             {
-                                attributes: {
-                                    eventMetric1: 'metric2',
-                                    journeyType: 'testjourneytype1',
-                                },
                                 coupon_code: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
@@ -292,12 +288,12 @@ describe('Google Analytics 4 Event', function () {
                                 price: 999,
                                 quantity: 1,
                                 total_amount: 999,
+                                eventMetric1: 'metric2',
+                                journeyType: 'testjourneytype1',
                             },
                             {
-                                attributes: {
-                                    eventMetric1: 'metric1',
-                                    journeyType: 'testjourneytype2',
-                                },
+                                eventMetric1: 'metric1',
+                                journeyType: 'testjourneytype2',
                                 coupon_code: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
@@ -780,10 +776,8 @@ describe('Google Analytics 4 Event', function () {
                         item_list_name: 'Related Products',
                         items: [
                             {
-                                attributes: {
-                                    eventMetric1: 'metric2',
-                                    journeyType: 'testjourneytype1',
-                                },
+                                eventMetric1: 'metric2',
+                                journeyType: 'testjourneytype1',
                                 coupon_code: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
@@ -796,10 +790,8 @@ describe('Google Analytics 4 Event', function () {
                                 total_amount: 999,
                             },
                             {
-                                attributes: {
-                                    eventMetric1: 'metric1',
-                                    journeyType: 'testjourneytype2',
-                                },
+                                eventMetric1: 'metric1',
+                                journeyType: 'testjourneytype2',
                                 coupon_code: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
@@ -1045,10 +1037,8 @@ describe('Google Analytics 4 Event', function () {
                         coupon: 'couponCode',
                         items: [
                             {
-                                attributes: {
-                                    eventMetric1: 'metric2',
-                                    journeyType: 'testjourneytype1',
-                                },
+                                eventMetric1: 'metric2',
+                                journeyType: 'testjourneytype1',
                                 coupon_code: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
@@ -1061,10 +1051,8 @@ describe('Google Analytics 4 Event', function () {
                                 total_amount: 999,
                             },
                             {
-                                attributes: {
-                                    eventMetric1: 'metric1',
-                                    journeyType: 'testjourneytype2',
-                                },
+                                eventMetric1: 'metric1',
+                                journeyType: 'testjourneytype2',
                                 coupon_code: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
@@ -1146,10 +1134,8 @@ describe('Google Analytics 4 Event', function () {
                         coupon: 'couponCode',
                         items: [
                             {
-                                attributes: {
-                                    eventMetric1: 'metric2',
-                                    journeyType: 'testjourneytype1',
-                                },
+                                eventMetric1: 'metric2',
+                                journeyType: 'testjourneytype1',
                                 coupon_code: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
@@ -1162,10 +1148,8 @@ describe('Google Analytics 4 Event', function () {
                                 total_amount: 999,
                             },
                             {
-                                attributes: {
-                                    eventMetric1: 'metric1',
-                                    journeyType: 'testjourneytype2',
-                                },
+                                eventMetric1: 'metric1',
+                                journeyType: 'testjourneytype2',
                                 coupon_code: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
@@ -1330,10 +1314,8 @@ describe('Google Analytics 4 Event', function () {
                         currency: 'USD',
                         items: [
                             {
-                                attributes: {
-                                    eventMetric1: 'metric2',
-                                    journeyType: 'testjourneytype1',
-                                },
+                                eventMetric1: 'metric2',
+                                journeyType: 'testjourneytype1',
                                 coupon_code: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
@@ -1346,10 +1328,8 @@ describe('Google Analytics 4 Event', function () {
                                 total_amount: 999,
                             },
                             {
-                                attributes: {
-                                    eventMetric1: 'metric1',
-                                    journeyType: 'testjourneytype2',
-                                },
+                                eventMetric1: 'metric1',
+                                journeyType: 'testjourneytype2',
                                 coupon_code: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',


### PR DESCRIPTION
## Summary
Custom Product Attributes should be on the same level as standard product attributes (price, quantity, etc).  CUrrent bug shows the attributes being sent as `[object Object]`.  

## Testing Plan
Added unit tests and sent tests in a test app and below screenshots show that the payload goes from showing `[object Object]` to the actual product attributes when sending an ecommerce event with the following product attributes:

```
var prodattr1 = {journeyType: 'testjourneytype1', eventMetric1: 'metric2'}
var prodattr2 = {'hit-att2': 'hit-att2-type', prodMetric1: 'metric1'}

var product1 = mParticle.eCommerce.createProduct('iphone', 'iphoneSKU', 999, 1, 'variant', 'category', 'brand', 1, 'coupon', prodattr1);
var product2 = mParticle.eCommerce.createProduct('galaxy', 'galaxySKU', 799, 1, 'variant', 'category', 'brand', 1, 'coupon', prodattr2);

```
Screenshot showing bug:
<img width="1162" alt="Screenshot 2023-09-01 at 5 09 07 PM" src="https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/assets/5377436/2a421cae-17a5-4c23-9658-84602b6a3376">

Screenshot showing bug fixed:
<img width="1187" alt="Screenshot 2023-09-01 at 5 08 45 PM" src="https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/assets/5377436/2fcb5a4d-02b0-440e-bf12-0a44e416e2c4">


## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-5642