### PR TITLE
feat: Implement max parameters for eCommerce events

### DIFF
--- a/packages/GA4Client/src/commerce-handler.js
+++ b/packages/GA4Client/src/commerce-handler.js
@@ -35,7 +35,8 @@ CommerceHandler.prototype.logCommerceEvent = function (event) {
     var needsCurrency = true,
         needsValue = true,
         ga4CommerceEventParameters,
-        isViewCartEvent = false;
+        isViewCartEvent = false,
+        customEventAttributes = event.EventAttributes || {};
 
     // GA4 has a view_cart event which MP does not support via a ProductActionType
     // In order to log a view_cart event, pass ProductActionType.Unknown along with
@@ -67,14 +68,7 @@ CommerceHandler.prototype.logCommerceEvent = function (event) {
     if (event.EventAttributes) {
         ga4CommerceEventParameters = this.common.mergeObjects(
             ga4CommerceEventParameters,
-            this.common.limitEventAttributes(event.EventAttributes)
-        );
-    }
-
-    // TODO: https://mparticle-eng.atlassian.net/browse/SQDSDKS-5714
-    if (this.common.forwarderSettings.enableDataCleansing) {
-        ga4CommerceEventParameters = this.common.standardizeParameters(
-            ga4CommerceEventParameters
+            event.EventAttributes
         );
     }
 
@@ -118,6 +112,18 @@ CommerceHandler.prototype.logCommerceEvent = function (event) {
                 return false;
             }
     }
+
+    // TODO: https://mparticle-eng.atlassian.net/browse/SQDSDKS-5714
+    if (this.common.forwarderSettings.enableDataCleansing) {
+        customEventAttributes = this.common.standardizeParameters(
+            customEventAttributes
+        );
+    }
+
+    ga4CommerceEventParameters = this.common.mergeObjects(
+        ga4CommerceEventParameters,
+        this.common.limitEventAttributes(customEventAttributes)
+    );
 
     // CheckoutOption, Promotions, and Impressions will not make it to this code
     if (needsCurrency) {

--- a/packages/GA4Client/src/commerce-handler.js
+++ b/packages/GA4Client/src/commerce-handler.js
@@ -67,7 +67,7 @@ CommerceHandler.prototype.logCommerceEvent = function (event) {
     if (event.EventAttributes) {
         ga4CommerceEventParameters = this.common.mergeObjects(
             ga4CommerceEventParameters,
-            event.EventAttributes
+            this.common.limitEventAttributes(event.EventAttributes)
         );
     }
 
@@ -473,6 +473,10 @@ function logImpressionEvent(event) {
 
 function logViewCart(event) {
     var ga4CommerceEventParameters = buildViewCart(event);
+    ga4CommerceEventParameters = self.common.mergeObjects(
+        ga4CommerceEventParameters,
+        self.common.limitEventAttributes(event.EventAttributes)
+    );
     ga4CommerceEventParameters.currency = event.CurrencyCode;
 
     ga4CommerceEventParameters.value =

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -1559,8 +1559,9 @@ describe('Google Analytics 4 Event', function () {
                 done();
             });
 
-            it('should limit the number of event attribute keys', function (done) {
-                var eventAttributeKeys = [
+            describe('limit event attributes', function () {
+                // 101 event attribute keys because the limit is 100
+                var eventAttributeKeys101 = [
                     'aa',
                     'ab',
                     'ac',
@@ -1663,26 +1664,85 @@ describe('Google Analytics 4 Event', function () {
                     'dv',
                     'dw',
                 ];
-    
-                var event = {
-                    CurrencyCode: 'USD',
-                    EventName: 'Test Purchase Event',
-                    EventDataType: MessageType.PageEvent,
-                    EventCategory: CommerceEventType.ProductImpression,
-                    EventAttributes: {},
-                };
-                // add on 101 event attributes
-                eventAttributeKeys.forEach(function (key) {
-                    event.EventAttributes[key] = key;
+
+                it('should limit the number of event attribute keys', function (done) {
+                    var event = {
+                        CurrencyCode: 'USD',
+                        EventName: 'Test Purchase Event',
+                        EventDataType: MessageType.PageEvent,
+                        EventCategory: CommerceEventType.ProductImpression,
+                        EventAttributes: {},
+                    };
+                    // add on 101 event attributes
+                    eventAttributeKeys101.forEach(function (key) {
+                        event.EventAttributes[key] = key;
+                    });
+                    mParticle.forwarder.process(event);
+
+                    var resultEventAttributeKeys = Object.keys(dataLayer[0][2]);
+                    resultEventAttributeKeys.length.should.eql(100);
+                    // dw is the 101st item.  The limit is 100, so
+                    resultEventAttributeKeys.should.not.have.property('dw');
+
+                    done();
                 });
-                mParticle.forwarder.process(event);
-    
-                var resultEventAttributeKeys = Object.keys(dataLayer[0][2]);
-                resultEventAttributeKeys.length.should.eql(100);
-                // dw is the 101st item.  The limit is 100, so
-                resultEventAttributeKeys.should.not.have.property('dw');
-    
-                done();
+
+                it('should limit the number of event attribute keys on GA4 view cart commerce events', function (done) {
+                    var event = {
+                        CurrencyCode: 'USD',
+                        EventName: 'Unknown Test',
+                        EventDataType: MessageType.Commerce,
+                        EventAttributes: {},
+                        EventCategory: CommerceEventType.Unknown,
+                        CustomFlags: {
+                            'GA4.CommerceEventType': 'view_cart',
+                            'GA4.Value': 100,
+                        },
+                        ProductAction: {
+                            ProductActionType: ProductActionType.Unknown,
+                            ProductList: [],
+                        },
+                    };
+
+                    // add on 101 event attributes
+                    eventAttributeKeys101.forEach(function (key) {
+                        event.EventAttributes[key] = key;
+                    });
+                    mParticle.forwarder.process(event);
+
+                    var resultEventAttributeKeys = Object.keys(dataLayer[0][2]);
+                    // dw is the 101st item.  The limit is 100, so
+                    resultEventAttributeKeys.should.not.have.property('dw');
+
+                    done();
+                });
+
+                it('should limit the number of event attribute keys on product action commerce events', function (done) {
+                    var event = {
+                        CurrencyCode: 'USD',
+                        EventName: 'eCommerce - AddToCart',
+                        EventDataType: MessageType.Commerce,
+                        EventAttributes: {},
+                        EventCategory: CommerceEventType.ProductAddToCart,
+                        ProductAction: {
+                            ProductActionType: ProductActionType.Unknown,
+                            ProductList: [],
+                        },
+                    };
+
+                    // add on 101 event attributes
+                    eventAttributeKeys101.forEach(function (key) {
+                        event.EventAttributes[key] = key;
+                    });
+
+                    mParticle.forwarder.process(event);
+
+                    var resultEventAttributeKeys = Object.keys(dataLayer[0][2]);
+                    // dw is the 101st item.  The limit is 100, so
+                    resultEventAttributeKeys.should.not.have.property('dw');
+
+                    done();
+                });
             });
         });
 

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -1709,10 +1709,11 @@ describe('Google Analytics 4 Event', function () {
                         event.EventAttributes[key] = key;
                     });
                     mParticle.forwarder.process(event);
-
                     var resultEventAttributeKeys = Object.keys(dataLayer[0][2]);
+                    // confirm event attribuets have been successfully set
+                    resultEventAttributeKeys.includes('aa').should.equal(true);
                     // dw is the 101st item.  The limit is 100, so
-                    resultEventAttributeKeys.should.not.have.property('dw');
+                    resultEventAttributeKeys.includes('dw').should.equal(false);
 
                     done();
                 });
@@ -1738,8 +1739,10 @@ describe('Google Analytics 4 Event', function () {
                     mParticle.forwarder.process(event);
 
                     var resultEventAttributeKeys = Object.keys(dataLayer[0][2]);
+                    // confirm event attribuets have been successfully set
+                    resultEventAttributeKeys.includes('aa').should.equal(true);
                     // dw is the 101st item.  The limit is 100, so
-                    resultEventAttributeKeys.should.not.have.property('dw');
+                    resultEventAttributeKeys.includes('dw').should.equal(false);
 
                     done();
                 });


### PR DESCRIPTION
## Summary
Add functionality to limit parameters for eCommerce events to 100 also.

## Testing Plan
Add unit test.  Send in a payload which has 101 keys, from `aa`, `ab`, `ac`, etc all the way to `dw`. `dw` is the 101st key, which gets removed from the payload when sending.  See screenshot below:

![image](https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/assets/5377436/708ff1a0-cf2c-4367-b169-1a9993285e0b)


## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-5733
