### PR TITLE
feat: Limit item params to 10 non-reserved keys

### DIFF
--- a/packages/GA4Client/src/commerce-handler.js
+++ b/packages/GA4Client/src/commerce-handler.js
@@ -261,15 +261,11 @@ function toUnderscore(string) {
 }
 
 function parseProduct(product) {
-    var productWithAllAttributes = {};
-
     // 1. Move key/value pairs from product.Attributes to be at the same level
-    // as all keys in product
-    if (product.Attributes) {
-        for (var prodAttr in product.Attributes) {
-            productWithAllAttributes[prodAttr] = product.Attributes[prodAttr];
-        }
-    }
+    // as all keys in product, limiting them to 10 in the process.
+    var productWithAllAttributes = self.common.limitProductAttributes(
+        product.Attributes
+    );
 
     // 2. Copy key/value pairs in product
     for (var key in product) {

--- a/packages/GA4Client/src/common.js
+++ b/packages/GA4Client/src/common.js
@@ -10,6 +10,16 @@ var EVENT_ATTRIBUTE_MAX_NUMBER = 100;
 var USER_ATTRIBUTE_KEY_MAX_LENGTH = 24;
 var USER_ATTRIBUTE_VALUE_MAX_LENGTH = 36;
 
+var PRODUCT_ATTRIBUTE_MAX_NUMBER = 10;
+
+var RESERVED_PRODUCT_KEYS = [
+    'item_category',
+    'item_category2',
+    'item_category3',
+    'item_category4',
+    'item_category5',
+];
+
 var FORBIDDEN_PREFIXES = ['google_', 'firebase_', 'ga_'];
 var FORBIDDEN_CHARACTERS_REGEX = /[^a-zA-Z0-9_]/g;
 
@@ -82,6 +92,26 @@ Common.prototype.limitAttributes = function (attributes, limitNumber) {
 
 Common.prototype.limitEventAttributes = function (attributes) {
     return this.limitAttributes(attributes, EVENT_ATTRIBUTE_MAX_NUMBER);
+};
+
+Common.prototype.limitProductAttributes = function (attributes) {
+    var productAttributes = {};
+    var reservedAttributes = {};
+
+    for (var key in attributes) {
+        if (RESERVED_PRODUCT_KEYS.indexOf(key) >= 0) {
+            reservedAttributes[key] = attributes[key];
+        } else {
+            productAttributes[key] = attributes[key];
+        }
+    }
+
+    var limitedProductAttributes = this.limitAttributes(
+        productAttributes,
+        PRODUCT_ATTRIBUTE_MAX_NUMBER
+    );
+
+    return this.mergeObjects(limitedProductAttributes, reservedAttributes);
 };
 
 Common.prototype.truncateEventName = function (eventName) {

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -1746,6 +1746,78 @@ describe('Google Analytics 4 Event', function () {
 
                     done();
                 });
+
+                it('should limit the number of event attribute keys on items to 10', function (done) {
+                    var event = {
+                        CurrencyCode: 'USD',
+                        EventName: 'eCommerce - AddToCart',
+                        EventDataType: MessageType.Commerce,
+                        EventAttributes: {},
+                        EventCategory: CommerceEventType.ProductAddToCart,
+                        ProductAction: {
+                            ProductActionType: ProductActionType.Unknown,
+                            ProductList: [
+                                {
+                                    Attributes: {
+                                        item_category2: 'testjourneytype1',
+                                        a: 'foo',
+                                        b: 'foo',
+                                        c: 'foo',
+                                        d: 'foo',
+                                        e: 'foo',
+                                        f: 'foo',
+                                        g: 'foo',
+                                        h: 'foo',
+                                        i: 'foo',
+                                        j: 'foo',
+                                        k: 'foo',
+                                    },
+                                    Brand: 'brand',
+                                    Category: 'category',
+                                    Name: 'iphone',
+                                    Position: 1,
+                                    Price: 999,
+                                    Quantity: 1,
+                                    Sku: 'iphoneSKU',
+                                    TotalAmount: 999,
+                                    Variant: 'variant',
+                                },
+                            ],
+                        },
+                    };
+
+                    mParticle.forwarder.process(event);
+
+                    // We filter out k from the attributes because it is the 11th item
+                    // while retaining item_category2 since this is a reserved key
+                    var item1 = {
+                        item_category2: 'testjourneytype1',
+                        a: 'foo',
+                        b: 'foo',
+                        c: 'foo',
+                        d: 'foo',
+                        e: 'foo',
+                        f: 'foo',
+                        g: 'foo',
+                        h: 'foo',
+                        i: 'foo',
+                        j: 'foo',
+                        item_brand: 'brand',
+                        item_category: 'category',
+                        item_id: 'iphoneSKU',
+                        item_name: 'iphone',
+                        item_variant: 'variant',
+                        position: 1,
+                        price: 999,
+                        quantity: 1,
+                        total_amount: 999,
+                    };
+
+                    // Ths 1st item shoudl match the result above, removing `k`
+                    window.dataLayer[0][2].items[0].should.match(item1);
+
+                    done();
+                });
             });
         });
 


### PR DESCRIPTION
## Summary
Limit item parameters to 10 non-reserved keys.  Customers can have up to 10 keys in addition to `item_category2/3/4/5`. 

## Testing Plan
Unit tests added.  Screenshot shows a product being sent with item attributes that include `a`-`k`, along with an `item_category2`.  The payload shows that these are sent as `k0a`, `k1b`, `k2c`...all the way to `k9j` (thus dropping `k`, the 11th parameter alphabetically), and also includes `item_category2` sent as `c2` in the payload.  
<img width="1112" alt="image" src="https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/assets/5377436/689c3358-06c7-4d6d-be38-309f13a69e77">

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-5731