### PR TITLE
fix: Map CouponCode to reserved attributes `coupon` instead of `coupon_code`

### DIFF
--- a/packages/GA4Client/src/commerce-handler.js
+++ b/packages/GA4Client/src/commerce-handler.js
@@ -282,6 +282,9 @@ function parseProduct(product) {
             case 'Category':
                 productWithAllAttributes.item_category = product.Category;
                 break;
+            case 'CouponCode':
+                productWithAllAttributes.coupon = product.CouponCode;
+                break;
             case 'Variant':
                 productWithAllAttributes.item_variant = product.Variant;
                 break;

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -279,7 +279,7 @@ describe('Google Analytics 4 Event', function () {
                         value: 100,
                         items: [
                             {
-                                coupon_code: 'coupon',
+                                coupon: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
                                 item_id: 'iphoneSKU',
@@ -295,7 +295,7 @@ describe('Google Analytics 4 Event', function () {
                             {
                                 eventMetric1: 'metric1',
                                 journeyType: 'testjourneytype2',
-                                coupon_code: 'coupon',
+                                coupon: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
                                 item_id: 'iphoneSKU',
@@ -779,7 +779,7 @@ describe('Google Analytics 4 Event', function () {
                             {
                                 eventMetric1: 'metric2',
                                 journeyType: 'testjourneytype1',
-                                coupon_code: 'coupon',
+                                coupon: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
                                 item_id: 'iphoneSKU',
@@ -793,7 +793,7 @@ describe('Google Analytics 4 Event', function () {
                             {
                                 eventMetric1: 'metric1',
                                 journeyType: 'testjourneytype2',
-                                coupon_code: 'coupon',
+                                coupon: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
                                 item_id: 'iphoneSKU',
@@ -1040,7 +1040,7 @@ describe('Google Analytics 4 Event', function () {
                             {
                                 eventMetric1: 'metric2',
                                 journeyType: 'testjourneytype1',
-                                coupon_code: 'coupon',
+                                coupon: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
                                 item_id: 'iphoneSKU',
@@ -1054,7 +1054,7 @@ describe('Google Analytics 4 Event', function () {
                             {
                                 eventMetric1: 'metric1',
                                 journeyType: 'testjourneytype2',
-                                coupon_code: 'coupon',
+                                coupon: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
                                 item_id: 'iphoneSKU',
@@ -1137,7 +1137,7 @@ describe('Google Analytics 4 Event', function () {
                             {
                                 eventMetric1: 'metric2',
                                 journeyType: 'testjourneytype1',
-                                coupon_code: 'coupon',
+                                coupon: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
                                 item_id: 'iphoneSKU',
@@ -1151,7 +1151,7 @@ describe('Google Analytics 4 Event', function () {
                             {
                                 eventMetric1: 'metric1',
                                 journeyType: 'testjourneytype2',
-                                coupon_code: 'coupon',
+                                coupon: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
                                 item_id: 'iphoneSKU',
@@ -1317,7 +1317,7 @@ describe('Google Analytics 4 Event', function () {
                             {
                                 eventMetric1: 'metric2',
                                 journeyType: 'testjourneytype1',
-                                coupon_code: 'coupon',
+                                coupon: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
                                 item_id: 'iphoneSKU',
@@ -1331,7 +1331,7 @@ describe('Google Analytics 4 Event', function () {
                             {
                                 eventMetric1: 'metric1',
                                 journeyType: 'testjourneytype2',
-                                coupon_code: 'coupon',
+                                coupon: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
                                 item_id: 'iphoneSKU',
@@ -1820,7 +1820,6 @@ describe('Google Analytics 4 Event', function () {
                 });
             });
         });
-
     });
 
     describe('identity', function () {
@@ -2047,7 +2046,7 @@ describe('Google Analytics 4 Event', function () {
                                 eventMetric1: 'metric1',
                                 journeyType: 'testjourneytype2',
                                 test4ever___: 'tester',
-                                coupon_code: 'coupon',
+                                coupon: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
                                 item_id: 'iphoneSKU',
@@ -2132,7 +2131,7 @@ describe('Google Analytics 4 Event', function () {
                             {
                                 eventMetric1: 'metric2',
                                 journeyType: 'testjourneytype1',
-                                coupon_code: 'coupon',
+                                coupon: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
                                 item_id: 'iphoneSKU',
@@ -2149,7 +2148,7 @@ describe('Google Analytics 4 Event', function () {
                             {
                                 eventMetric1: 'metric1',
                                 journeyType: 'testjourneytype2',
-                                coupon_code: 'coupon',
+                                coupon: 'coupon',
                                 item_brand: 'brand',
                                 item_category: 'category',
                                 item_id: 'iphoneSKU',


### PR DESCRIPTION
## Summary
We were mapping product item coupons to `coupon_code` instead of `coupon` which GA4 has a reserved attribute for.

## Testing Plan
1.  Fixed unit tests where `CouponCode` was being mapped to `coupon_code`.  
2.  Tested in local test app, 1st screenshot shows payload with bug, where `coupon_code` is passed as a non-reserved keyword as `k0coupon_code~v0coupon123123`.  2nd screenshot shows fixed payload where `coupon` is sent as the reserved keyword, which GA4's SDK sends as `cpcoupon123123` differently.

Screenshot1
![image](https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/assets/5377436/6f18c47b-6115-4817-a51f-41ff164c5982)

Screenshot2
![image](https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/assets/5377436/d6733294-9892-4f19-9054-4b4429dd831b)

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-5640