### PR TITLE
fix: Re-map affiliation from event level to item level

### DIFF
--- a/packages/GA4Client/src/commerce-handler.js
+++ b/packages/GA4Client/src/commerce-handler.js
@@ -140,13 +140,6 @@ CommerceHandler.prototype.logCommerceEvent = function (event) {
     return true;
 };
 
-function buildParameters(event, affiliation) {
-    return {
-        items: buildProductsList(event.ProductAction.ProductList, affiliation),
-        coupon: event.ProductAction ? event.ProductAction.CouponCode : null,
-    };
-}
-
 function buildAddOrRemoveCartItem(event, affiliation) {
     return {
         items: buildProductsList(event.ProductAction.ProductList, affiliation),

--- a/packages/GA4Client/src/commerce-handler.js
+++ b/packages/GA4Client/src/commerce-handler.js
@@ -34,7 +34,7 @@ var ADD_SHIPPING_INFO = 'add_shipping_info',
 CommerceHandler.prototype.logCommerceEvent = function (event) {
     var needsCurrency = true,
         needsValue = true,
-        ga4CommerceEventParameters,
+        ga4CommerceEventParameters = {},
         isViewCartEvent = false,
         customEventAttributes = event.EventAttributes || {},
         // affiliation potentially lives on any commerce event with items
@@ -66,15 +66,6 @@ CommerceHandler.prototype.logCommerceEvent = function (event) {
         event.EventCategory === PromotionActionTypes.PromotionView
     ) {
         return logPromotionEvent(event);
-    }
-
-    ga4CommerceEventParameters = buildParameters(event, affiliation);
-
-    if (event.EventAttributes) {
-        ga4CommerceEventParameters = this.common.mergeObjects(
-            ga4CommerceEventParameters,
-            event.EventAttributes
-        );
     }
 
     switch (event.EventCategory) {

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -535,7 +535,8 @@ describe('Google Analytics 4 Event', function () {
                 result[1] = 'purchase';
                 result[2].coupon = 'couponCode';
                 result[2].transaction_id = 'foo-transaction-id';
-                result[2].affiliation = 'foo-affiliation-id';
+                result[2].items[0].affiliation = 'foo-affiliation-id';
+                result[2].items[1].affiliation = 'foo-affiliation-id';
                 result[2].shipping = 10;
                 result[2].tax = 40;
                 result[2].value = 450;
@@ -598,7 +599,8 @@ describe('Google Analytics 4 Event', function () {
                 result[1] = 'refund';
                 result[2].coupon = 'couponCode';
                 result[2].transaction_id = 'foo-transaction-id';
-                result[2].affiliation = 'foo-affiliation-id';
+                result[2].items[0].affiliation = 'foo-affiliation-id';
+                result[2].items[1].affiliation = 'foo-affiliation-id';
                 result[2].shipping = 10;
                 result[2].tax = 40;
                 result[2].value = 450;
@@ -1361,6 +1363,65 @@ describe('Google Analytics 4 Event', function () {
                 });
 
                 window.dataLayer.length.should.eql(0);
+
+                done();
+            });
+
+            it('should prioritize affiliation for an item over event level affiliation', function (done) {
+                mParticle.forwarder.process({
+                    CurrencyCode: 'USD',
+                    EventName: 'Test Purchase Event',
+                    EventDataType: MessageType.Commerce,
+                    EventCategory: CommerceEventType.ProductAddToCart,
+                    CustomFlags: { 'GA4.Value': 100 },
+                    ProductAction: {
+                        ProductActionType: ProductActionType.AddToCart,
+                        ProductList: [
+                            {
+                                Attributes: {
+                                    eventMetric1: 'metric2',
+                                    journeyType: 'testjourneytype1',
+                                    affiliation: 'product-level-affiliation',
+                                },
+                                Brand: 'brand',
+                                Category: 'category',
+                                CouponCode: 'coupon',
+                                Name: 'iphone',
+                                Position: 1,
+                                Price: 999,
+                                Quantity: 1,
+                                Sku: 'iphoneSKU',
+                                TotalAmount: 999,
+                                Variant: 'variant',
+                            },
+                            {
+                                Attributes: {
+                                    eventMetric1: 'metric1',
+                                    journeyType: 'testjourneytype2',
+                                },
+                                Brand: 'brand',
+                                Category: 'category',
+                                CouponCode: 'coupon',
+                                Name: 'iphone',
+                                Position: 1,
+                                Price: 999,
+                                Quantity: 1,
+                                Sku: 'iphoneSKU',
+                                TotalAmount: 999,
+                                Variant: 'variant',
+                            },
+                        ],
+                        Affiliation: 'event-level-affiliation',
+                        TaxAmount: 40,
+                        ShippingAmount: 10,
+                        CouponCode: 'coupon',
+                    },
+                });
+
+                result[1] = 'add_to_cart';
+                result[2].items[0].affiliation = 'product-level-affiliation';
+                result[2].items[1].affiliation = 'event-level-affiliation';
+                window.dataLayer[0].should.eql(result);
 
                 done();
             });


### PR DESCRIPTION
## Summary
`affiliation` is supposed to be item level and not event level as we currently have it.  There are lots of small code edits in this PR because each commerce action has its own `build` step, and almost all build steps also call the `buildProductsList` function (which now needs the affiliation).  

DRY-ing this up would have been a larger ticket, and I started down that path, but there began to be some significant code changes which are out of the scope of this ticket.  We can DRY it up per this sustained engineering ticket - https://mparticle-eng.atlassian.net/browse/SQDSDKS-5716

## Testing Plan
Fixed all unit tests where affiliation was at the event level.  Added a unit test to test a product with and without `affiliation` as a product attribute, and the behavior if there is an event level attribute.  The product level `affiliation` will take priority over the event level affiliation.

See screenshot 1 which shows buggy behavior - affiliation is on the event

Screenshot 2 shows affiliation on product 1 and product 2.  In the case of product 1, we pass a `product-level-affiliation` as an attribute so that takes priority over the `event-level-affiliation`.  In product 2, no affiliation is passed as a product attribute, and so the `event-level-affiliation` is used


Screenshot 1
![Screenshot 2023-09-07 at 4 56 08 PM](https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/assets/5377436/b4cc94f9-274a-4c9c-aa25-e173c2c0eabf)

Screenshot 2
![Screenshot 2023-09-07 at 4 55 02 PM](https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/assets/5377436/39379888-543d-4530-8263-7a234612011c)

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-5611
