### PR TITLE
fix: Prevent attribute cleansing when data cleansing is disabled

### DIFF
--- a/packages/GA4Client/src/common.js
+++ b/packages/GA4Client/src/common.js
@@ -58,11 +58,7 @@ Common.prototype.truncateAttributes = function (
 
     if (!isEmpty(attributes)) {
         Object.keys(attributes).forEach(function (attribute) {
-            var standardizedKey = attribute.replace(
-                FORBIDDEN_CHARACTERS_REGEX,
-                '_'
-            );
-            var key = truncateString(standardizedKey, keyLimit);
+            var key = truncateString(attribute, keyLimit);
             var val = truncateString(attributes[attribute], valueLimit);
             truncatedAttributes[key] = val;
         });

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -1571,6 +1571,29 @@ describe('Google Analytics 4 Event', function () {
                 done();
             });
 
+            it('should not standardize event names and event attributes if data cleansing is not enabled', function (done) {
+                mParticle.forwarder.process({
+                    EventDataType: MessageType.PageEvent,
+                    EventCategory: EventType.Navigation,
+                    EventName: '2?Test Event ?Standardization',
+                    EventAttributes: {
+                        foo: 'bar',
+                        '1?test4ever!!!': 'tester',
+                    },
+                });
+
+                var expectedEventName = '2?Test Event ?Standardization';
+
+                var expectedEventAttributes = {
+                    foo: 'bar',
+                    '1?test4ever!!!': 'tester',
+                };
+
+                window.dataLayer[0][1].should.eql(expectedEventName);
+                window.dataLayer[0][2].should.eql(expectedEventAttributes);
+                done();
+            });
+
             // This test exist for backwards compatibility of custom flags carried
             // over from legacy Google Analytics - Google.Title and Google.Location
             it('should log page view with legacy GA custom flags', function (done) {


### PR DESCRIPTION
## Summary
In my testing, I found that cleansing for attributes was still being done even if data cleansing was false.  It looks like these lines related to regex-ing the attribute name was not removed https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/pull/36/files#diff-2d099ec65653b8719574234ce177bf327823ed04ed4935d0483643596e1f50f6R49-R53

## Testing Plan
Added a unit test to ensure attribute is not cleansed if enable data cleansing is off.

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-5752