### PR TITLE
feat: Add Customer Configurable Standardization

### DIFF
--- a/packages/GA4Client/src/common.js
+++ b/packages/GA4Client/src/common.js
@@ -136,7 +136,7 @@ Common.prototype.standardizeName = function (name) {
         name = window.GoogleAnalytics4Kit.setCustomNameStandardization(name);
     } catch (e) {
         console.error(
-            'Error calling setCustomNameStandardization callback. Check your callback.  Data will still be sent without user-defined standardization',
+            'Error calling setCustomNameStandardization callback. Check your callback.  Data will still be sent without user-defined standardization. See our docs for proper use - https://docs.mparticle.com/integrations/google-analytics-4/event/',
             e
         );
     }

--- a/packages/GA4Client/src/common.js
+++ b/packages/GA4Client/src/common.js
@@ -135,7 +135,7 @@ Common.prototype.standardizeName = function (name) {
     try {
         name = window.GoogleAnalytics4Kit.setCustomNameStandardization(name);
     } catch (e) {
-        console.warn(
+        console.error(
             'Error calling setCustomNameStandardization callback. Check your callback.  Data will still be sent without user-defined standardization',
             e
         );

--- a/packages/GA4Client/src/common.js
+++ b/packages/GA4Client/src/common.js
@@ -132,6 +132,15 @@ Common.prototype.standardizeParameters = function (parameters) {
 };
 
 Common.prototype.standardizeName = function (name) {
+    try {
+        name = window.GoogleAnalytics4Kit.setCustomNameStandardization(name);
+    } catch (e) {
+        console.warn(
+            'Error calling setCustomNameStandardization callback. Check your callback.  Data will still be sent without user-defined standardization',
+            e
+        );
+    }
+
     // names of events and parameters have the following requirements:
     // 1. They must only contain letters, numbers, and underscores
     function removeForbiddenCharacters(name) {

--- a/packages/GA4Client/src/initialization.js
+++ b/packages/GA4Client/src/initialization.js
@@ -1,4 +1,6 @@
 var initialization = {
+    // This name matches the mParticle database. This should not be changed unless the database name is being changed
+    // Changing this will also break the API for the cleansing data callback that a customer uses.
     name: 'GoogleAnalytics4',
     moduleId: 160,
     /*  ****** Fill out initForwarder to load your SDK ******
@@ -21,6 +23,13 @@ var initialization = {
     ) {
         mParticle._setIntegrationDelay(this.moduleId, true);
 
+        // Due to current limitations, the API for allowing a customer to cleanse
+        // their data before our cleansing occurs must be placed on the
+        // window.GoogleAnalytics4Kit object.  This exists when initializing MP
+        // SDK via snippet, but not via npm. If a customer uses npm, using the API
+        // requires window.GoogleAnalytics4Kit to exist on the page.
+        window.GoogleAnalytics4Kit = window.GoogleAnalytics4Kit || {};
+
         common.forwarderSettings = forwarderSettings;
         common.forwarderSettings.enableDataCleansing =
             common.forwarderSettings.enableDataCleansing === 'True';
@@ -29,7 +38,7 @@ var initialization = {
         var hashUserId = forwarderSettings.hashUserId;
 
         var configSettings = {
-            send_page_view: forwarderSettings.enablePageView === 'True'
+            send_page_view: forwarderSettings.enablePageView === 'True',
         };
         window.dataLayer = window.dataLayer || [];
 

--- a/packages/GA4Client/src/initialization.js
+++ b/packages/GA4Client/src/initialization.js
@@ -23,11 +23,11 @@ var initialization = {
     ) {
         mParticle._setIntegrationDelay(this.moduleId, true);
 
-        // Due to current limitations, the API for allowing a customer to cleanse
-        // their data before our cleansing occurs must be placed on the
-        // window.GoogleAnalytics4Kit object.  This exists when initializing MP
-        // SDK via snippet, but not via npm. If a customer uses npm, using the API
-        // requires window.GoogleAnalytics4Kit to exist on the page.
+        // The API to allow a customer to provide the cleansing callback
+        // relies on window.GoogleAnalytics4Kit to exist. When MP is initialized
+        // via the snippet, the kit code adds it to the window automatically.
+        // However, when initialized via npm, it does not exist, and so we have 
+        // to set it manually here.
         window.GoogleAnalytics4Kit = window.GoogleAnalytics4Kit || {};
 
         common.forwarderSettings = forwarderSettings;

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -2021,6 +2021,38 @@ describe('Google Analytics 4 Event', function () {
                 done();
             });
 
+            it('should standardize event names and attributes keys using user provided cleansing callback first, and then our standardization', function (done) {
+                window.GoogleAnalytics4Kit.setCustomNameStandardization =
+                    function (str) {
+                        return str.slice(0, str.length - 1);
+                    };
+
+                mParticle.forwarder.process({
+                    EventDataType: MessageType.PageEvent,
+                    EventCategory: EventType.Navigation,
+                    EventName: '2?Test Event ?Standardization',
+                    EventAttributes: {
+                        foo: 'bar',
+                        '1?test4ever!!!': 'tester',
+                    },
+                });
+
+                var expectedEventName = 'Test_Event__Standardizatio';
+
+                var expectedEventAttributes = {
+                    fo: 'bar',
+                    test4ever__: 'tester',
+                };
+
+                window.dataLayer[0][1].should.eql(expectedEventName);
+                window.dataLayer[0][2].should.eql(expectedEventAttributes);
+
+                // remove this function so that it doesn't affect other tests
+                delete window.GoogleAnalytics4Kit.setCustomNameStandardization;
+
+                done();
+            });
+
             it('should remove forbidden prefixes', function (done) {
                 mParticle.forwarder.process({
                     EventDataType: MessageType.PageEvent,


### PR DESCRIPTION
## Summary
This PR allows a customer to pass a standardization callback for name that affects event name, custom attributes, and product attributes.

## Testing Plan
Added unit tests.  Tested locally. 

The callback I used was to remove the last letter of each string.

Screen shot 1 shows a transaction sent with product attributes and custom attributes. 
<img width="1231" alt="image" src="https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/assets/5377436/bdff5236-b379-479a-a284-42c91bc035b7">
Note that `eventMetric1` gets shortened to `eventMetric` in the payload. `journeyType` --> `journeyTyp`, and `sale` --> `sal`.

Screenshot 2
<img width="1038" alt="image" src="https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/assets/5377436/2f198144-751b-4c93-baf3-2ad098f19183">
Shows `name` --> `nam`, `abc` --> `ab`, and `def` --> `de`.

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-5641