### PR TITLE
fix:add check and replace warn instead of error for setCustomNameStan…

### DIFF
--- a/packages/GA4Client/src/common.js
+++ b/packages/GA4Client/src/common.js
@@ -132,7 +132,7 @@ Common.prototype.standardizeParameters = function (parameters) {
 };
 
 Common.prototype.standardizeName = function (name) {
-    if (window.GoogleAnalytics4Kit.hasOwnProperty(setCustomNameStandardization)) {
+    if (window.GoogleAnalytics4Kit.hasOwnProperty('setCustomNameStandardization')) {
         try {
             name = window.GoogleAnalytics4Kit.setCustomNameStandardization(name);
         } catch (e) {

--- a/packages/GA4Client/src/common.js
+++ b/packages/GA4Client/src/common.js
@@ -132,13 +132,15 @@ Common.prototype.standardizeParameters = function (parameters) {
 };
 
 Common.prototype.standardizeName = function (name) {
-    try {
-        name = window.GoogleAnalytics4Kit.setCustomNameStandardization(name);
-    } catch (e) {
-        console.error(
-            'Error calling setCustomNameStandardization callback. Check your callback.  Data will still be sent without user-defined standardization. See our docs for proper use - https://docs.mparticle.com/integrations/google-analytics-4/event/',
-            e
-        );
+    if (window.GoogleAnalytics4Kit.setCustomNameStandardization(name)) {
+        try {
+            name = window.GoogleAnalytics4Kit.setCustomNameStandardization(name);
+        } catch (e) {
+            console.warn(
+                'Error calling setCustomNameStandardization callback. Check your callback.  Data will still be sent without user-defined standardization. See our docs for proper use - https://docs.mparticle.com/integrations/google-analytics-4/event/',
+                e
+            );
+        }
     }
 
     // names of events and parameters have the following requirements:

--- a/packages/GA4Client/src/common.js
+++ b/packages/GA4Client/src/common.js
@@ -132,7 +132,7 @@ Common.prototype.standardizeParameters = function (parameters) {
 };
 
 Common.prototype.standardizeName = function (name) {
-    if (window.GoogleAnalytics4Kit.setCustomNameStandardization(name)) {
+    if (window.GoogleAnalytics4Kit.hasOwnProperty(setCustomNameStandardization)) {
         try {
             name = window.GoogleAnalytics4Kit.setCustomNameStandardization(name);
         } catch (e) {


### PR DESCRIPTION
…dardization

## Summary
https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/issues/54

## Testing Plan
Added code to local overrides and tested the warn instead error and then added the if statement to check the callback.

## Master Issue
Closes https://go.mparticle.com/work/REPLACE
