### PR TITLE
feat: Add support for Consent State

### DIFF
--- a/packages/GA4Client/src/common.js
+++ b/packages/GA4Client/src/common.js
@@ -36,7 +36,7 @@ function isEmpty(value) {
 }
 
 function Common() {
-    this.consentMappings = {};
+    this.consentMappings = [];
     this.consentPayloadDefaults = {};
     this.consentPayloadAsString = '';
 
@@ -316,5 +316,7 @@ Common.prototype.getUserId = function (
 Common.prototype.cloneObject = function (obj) {
     return JSON.parse(JSON.stringify(obj));
 };
+
+Common.prototype.isEmpty = isEmpty;
 
 module.exports = Common;

--- a/packages/GA4Client/src/common.js
+++ b/packages/GA4Client/src/common.js
@@ -2,6 +2,8 @@
 // in place when sending to data layer.
 // https://support.google.com/analytics/answer/11202874?sjid=7958830619827381593-NA
 
+var ConsentHandler = require('./consent');
+
 var EVENT_NAME_MAX_LENGTH = 40;
 var EVENT_ATTRIBUTE_KEY_MAX_LENGTH = 40;
 var EVENT_ATTRIBUTE_VAL_MAX_LENGTH = 100;
@@ -33,7 +35,13 @@ function isEmpty(value) {
     return value == null || !(Object.keys(value) || value).length;
 }
 
-function Common() {}
+function Common() {
+    this.consentMappings = {};
+    this.consentPayloadDefaults = {};
+    this.consentPayloadAsString = '';
+
+    this.consentHandler = new ConsentHandler(this);
+}
 
 Common.prototype.forwarderSettings = null;
 
@@ -303,6 +311,10 @@ Common.prototype.getUserId = function (
         }
         return userId;
     }
+};
+
+Common.prototype.cloneObject = function (obj) {
+    return JSON.parse(JSON.stringify(obj));
 };
 
 module.exports = Common;

--- a/packages/GA4Client/src/consent.js
+++ b/packages/GA4Client/src/consent.js
@@ -13,6 +13,7 @@ var googleConsentValues = {
     Granted: 'granted',
 };
 
+// Declares list of valid Google Consent Properties
 var googleConsentProperties = [
     'ad_storage',
     'ad_user_data',
@@ -25,13 +26,13 @@ function ConsentHandler(common) {
 }
 
 ConsentHandler.prototype.getUserConsentState = function () {
-    var userConsentState = null;
+    var userConsentState = {};
 
     if (mParticle.Identity && mParticle.Identity.getCurrentUser) {
         var currentUser = mParticle.Identity.getCurrentUser();
 
         if (!currentUser) {
-            return null;
+            return {};
         }
 
         var consentState =
@@ -48,16 +49,19 @@ ConsentHandler.prototype.getUserConsentState = function () {
 ConsentHandler.prototype.getEventConsentState = function (eventConsentState) {
     return eventConsentState && eventConsentState.getGDPRConsentState
         ? eventConsentState.getGDPRConsentState()
-        : null;
+        : {};
 };
 
 ConsentHandler.prototype.getConsentSettings = function () {
     var consentSettings = {};
 
     var googleToMpConsentSettingsMapping = {
+        // Inherited from S2S Integration Settings
+        ad_user_data: 'adUserDataConsent',
+        ad_personalization: 'adPersonalizationConsent',
+
+        // Unique to Web Kits
         ad_storage: 'adStorageConsentSDK',
-        ad_user_data: 'adUserDataConsentSDK',
-        ad_personalization: 'adPersonalizationConsentSDK',
         analytics_storage: 'analyticsStorageConsentSDK',
     };
 
@@ -83,6 +87,8 @@ ConsentHandler.prototype.generateConsentStatePayloadFromMappings = function (
     consentState,
     mappings
 ) {
+    if (!mappings) return {};
+
     var payload = this.common.cloneObject(this.common.consentPayloadDefaults);
 
     for (var i = 0; i <= mappings.length - 1; i++) {

--- a/packages/GA4Client/src/consent.js
+++ b/packages/GA4Client/src/consent.js
@@ -56,10 +56,10 @@ ConsentHandler.prototype.getConsentSettings = function () {
     var consentSettings = {};
 
     var googleToMpConsentSettingsMapping = {
-        ad_user_data: 'adUserDataConsentSDK',
-        ad_personalization: 'adPersonalizationConsentSDK',
-        ad_storage: 'adStorageConsentSDK',
-        analytics_storage: 'analyticsStorageConsentSDK',
+        ad_user_data: 'defaultAdUserDataConsentSDK',
+        ad_personalization: 'defaultAdPersonalizationConsentSDK',
+        ad_storage: 'defaultAdStorageConsentSDK',
+        analytics_storage: 'defaultAnalyticsStorageConsentSDK',
     };
 
     var forwarderSettings = this.common.forwarderSettings;

--- a/packages/GA4Client/src/consent.js
+++ b/packages/GA4Client/src/consent.js
@@ -1,0 +1,107 @@
+var googleConsentValues = {
+    // Server Integration uses 'Unspecified' as a value when the setting is 'not set'.
+    // However, this is not used by Google's Web SDK. We are referencing it here as a comment
+    // as a record of this distinction and for posterity.
+    // If Google ever adds this for web, the line can just be uncommented to support this.
+    //
+    // Docs:
+    // Web: https://developers.google.com/tag-platform/gtagjs/reference#consent
+    // S2S: https://developers.google.com/google-ads/api/reference/rpc/v15/ConsentStatusEnum.ConsentStatus
+    //
+    // Unspecified: 'unspecified',
+    Denied: 'denied',
+    Granted: 'granted',
+};
+
+var googleConsentProperties = [
+    'ad_storage',
+    'ad_user_data',
+    'ad_personalization',
+    'analytics_storage',
+];
+
+function ConsentHandler(common) {
+    this.common = common || {};
+}
+
+ConsentHandler.prototype.getUserConsentState = function () {
+    var userConsentState = null;
+
+    if (mParticle.Identity && mParticle.Identity.getCurrentUser) {
+        var currentUser = mParticle.Identity.getCurrentUser();
+
+        if (!currentUser) {
+            return null;
+        }
+
+        var consentState =
+            mParticle.Identity.getCurrentUser().getConsentState();
+
+        if (consentState && consentState.getGDPRConsentState) {
+            userConsentState = consentState.getGDPRConsentState();
+        }
+    }
+
+    return userConsentState;
+};
+
+ConsentHandler.prototype.getEventConsentState = function (eventConsentState) {
+    return eventConsentState && eventConsentState.getGDPRConsentState
+        ? eventConsentState.getGDPRConsentState()
+        : null;
+};
+
+ConsentHandler.prototype.getConsentSettings = function () {
+    var consentSettings = {};
+
+    var googleToMpConsentSettingsMapping = {
+        ad_storage: 'adStorageConsentWeb',
+        ad_user_data: 'adUserDataConsentWeb',
+        ad_personalization: 'adPersonalizationConsentWeb',
+        analytics_storage: 'analyticsStorageConsentWeb',
+    };
+
+    var forwarderSettings = this.common.forwarderSettings;
+
+    Object.keys(googleToMpConsentSettingsMapping).forEach(function (
+        googleConsentKey
+    ) {
+        var mpConsentSettingKey =
+            googleToMpConsentSettingsMapping[googleConsentKey];
+        var googleConsentValuesKey = forwarderSettings[mpConsentSettingKey];
+
+        if (googleConsentValuesKey && mpConsentSettingKey) {
+            consentSettings[googleConsentKey] =
+                googleConsentValues[googleConsentValuesKey];
+        }
+    });
+
+    return consentSettings;
+};
+
+ConsentHandler.prototype.generateConsentStatePayloadFromMappings = function (
+    consentState,
+    mappings
+) {
+    var payload = this.common.cloneObject(this.common.consentPayloadDefaults);
+
+    for (var i = 0; i <= mappings.length - 1; i++) {
+        var mappingEntry = mappings[i];
+        var mpMappedConsentName = mappingEntry.map;
+        var googleMappedConsentName = mappingEntry.value;
+
+        if (
+            consentState[mpMappedConsentName] &&
+            googleConsentProperties.indexOf(googleMappedConsentName) !== -1
+        ) {
+            payload[googleMappedConsentName] = consentState[mpMappedConsentName]
+                .Consented
+                ? googleConsentValues.Granted
+                : googleConsentValues.Denied;
+        }
+    }
+
+    return payload;
+};
+
+module.exports = ConsentHandler;

--- a/packages/GA4Client/src/consent.js
+++ b/packages/GA4Client/src/consent.js
@@ -56,10 +56,8 @@ ConsentHandler.prototype.getConsentSettings = function () {
     var consentSettings = {};
 
     var googleToMpConsentSettingsMapping = {
-        // Inherited from S2S Integration Settings
-        ad_user_data: 'adUserDataConsent',
-        ad_personalization: 'adPersonalizationConsent',
-
+        ad_user_data: 'adUserDataConsentSDK',
+        ad_personalization: 'adPersonalizationConsentSDK',
         ad_storage: 'adStorageConsentSDK',
         analytics_storage: 'analyticsStorageConsentSDK',
     };

--- a/packages/GA4Client/src/consent.js
+++ b/packages/GA4Client/src/consent.js
@@ -60,7 +60,6 @@ ConsentHandler.prototype.getConsentSettings = function () {
         ad_user_data: 'adUserDataConsent',
         ad_personalization: 'adPersonalizationConsent',
 
-        // Unique to Web Kits
         ad_storage: 'adStorageConsentSDK',
         analytics_storage: 'analyticsStorageConsentSDK',
     };

--- a/packages/GA4Client/src/consent.js
+++ b/packages/GA4Client/src/consent.js
@@ -55,10 +55,10 @@ ConsentHandler.prototype.getConsentSettings = function () {
     var consentSettings = {};
 
     var googleToMpConsentSettingsMapping = {
-        ad_storage: 'adStorageConsentWeb',
-        ad_user_data: 'adUserDataConsentWeb',
-        ad_personalization: 'adPersonalizationConsentWeb',
-        analytics_storage: 'analyticsStorageConsentWeb',
+        ad_storage: 'adStorageConsentSDK',
+        ad_user_data: 'adUserDataConsentSDK',
+        ad_personalization: 'adPersonalizationConsentSDK',
+        analytics_storage: 'analyticsStorageConsentSDK',
     };
 
     var forwarderSettings = this.common.forwarderSettings;

--- a/packages/GA4Client/src/event-handler.js
+++ b/packages/GA4Client/src/event-handler.js
@@ -3,22 +3,27 @@ function EventHandler(common) {
 }
 
 EventHandler.prototype.maybeSendConsentUpdateToGa4 = function (event) {
-    var eventConsentState = this.common.consentHandler.getEventConsentState(
-        event.ConsentState
-    );
+    // If consent payload is empty,
+    // we never sent an initial default consent state
+    // so we shouldn't send an update.
+    if (this.common.consentPayloadAsString && this.common.consentMappings) {
+        var eventConsentState = this.common.consentHandler.getEventConsentState(
+            event.ConsentState
+        );
 
-    if (eventConsentState) {
-        var updatedConsentPayload =
-            this.common.consentHandler.generateConsentStatePayloadFromMappings(
-                eventConsentState,
-                this.common.consentMappings
-            );
+        if (!this.common.isEmpty(eventConsentState)) {
+            var updatedConsentPayload =
+                this.common.consentHandler.generateConsentStatePayloadFromMappings(
+                    eventConsentState,
+                    this.common.consentMappings
+                );
 
-        var eventConsentAsString = JSON.stringify(updatedConsentPayload);
+            var eventConsentAsString = JSON.stringify(updatedConsentPayload);
 
-        if (eventConsentAsString !== this.common.consentPayloadAsString) {
-            gtag('consent', 'update', updatedConsentPayload);
-            this.common.consentPayloadAsString = eventConsentAsString;
+            if (eventConsentAsString !== this.common.consentPayloadAsString) {
+                gtag('consent', 'update', updatedConsentPayload);
+                this.common.consentPayloadAsString = eventConsentAsString;
+            }
         }
     }
 };

--- a/packages/GA4Client/src/initialization.js
+++ b/packages/GA4Client/src/initialization.js
@@ -41,9 +41,9 @@ var initialization = {
             send_page_view: forwarderSettings.enablePageView === 'True',
         };
 
-        if (forwarderSettings.consentMapping) {
+        if (forwarderSettings.consentMappingSDK) {
             common.consentMappings = parseSettingsString(
-                forwarderSettings.consentMapping
+                forwarderSettings.consentMappingSDK
             );
         } else {
             // Ensures consent mappings is an empty array

--- a/packages/GA4Client/src/initialization.js
+++ b/packages/GA4Client/src/initialization.js
@@ -41,10 +41,16 @@ var initialization = {
             send_page_view: forwarderSettings.enablePageView === 'True',
         };
 
-        if (forwarderSettings.consentMappingSDK) {
+        if (forwarderSettings.consentMapping) {
             common.consentMappings = parseSettingsString(
-                forwarderSettings.consentMappingSDK
+                forwarderSettings.consentMapping
             );
+        } else {
+            // Ensures consent mappings is an empty array
+            // for future use
+            common.consentMappings = [];
+            common.consentPayloadDefaults = {};
+            common.consentPayloadAsString = '';
         }
 
         window.dataLayer = window.dataLayer || [];
@@ -101,12 +107,13 @@ var initialization = {
             common.consentHandler.getConsentSettings();
         var initialConsentState = common.consentHandler.getUserConsentState();
 
-        if (common.consentPayloadDefaults && initialConsentState) {
-            var defaultConsentPayload =
-                common.consentHandler.generateConsentStatePayloadFromMappings(
-                    initialConsentState,
-                    common.consentMappings
-                );
+        var defaultConsentPayload =
+            common.consentHandler.generateConsentStatePayloadFromMappings(
+                initialConsentState,
+                common.consentMappings
+            );
+
+        if (!common.isEmpty(defaultConsentPayload)) {
             common.consentPayloadAsString = JSON.stringify(
                 defaultConsentPayload
             );

--- a/packages/GA4Client/src/initialization.js
+++ b/packages/GA4Client/src/initialization.js
@@ -26,7 +26,7 @@ var initialization = {
         // The API to allow a customer to provide the cleansing callback
         // relies on window.GoogleAnalytics4Kit to exist. When MP is initialized
         // via the snippet, the kit code adds it to the window automatically.
-        // However, when initialized via npm, it does not exist, and so we have 
+        // However, when initialized via npm, it does not exist, and so we have
         // to set it manually here.
         window.GoogleAnalytics4Kit = window.GoogleAnalytics4Kit || {};
 
@@ -41,9 +41,9 @@ var initialization = {
             send_page_view: forwarderSettings.enablePageView === 'True',
         };
 
-        if (forwarderSettings.consentMappingWeb) {
+        if (forwarderSettings.consentMappingSDK) {
             common.consentMappings = parseSettingsString(
-                forwarderSettings.consentMappingWeb
+                forwarderSettings.consentMappingSDK
             );
         }
 

--- a/packages/GA4Client/src/initialization.js
+++ b/packages/GA4Client/src/initialization.js
@@ -40,6 +40,13 @@ var initialization = {
         var configSettings = {
             send_page_view: forwarderSettings.enablePageView === 'True',
         };
+
+        if (forwarderSettings.consentMappingWeb) {
+            common.consentMappings = parseSettingsString(
+                forwarderSettings.consentMappingWeb
+            );
+        }
+
         window.dataLayer = window.dataLayer || [];
 
         window.gtag = function () {
@@ -89,6 +96,24 @@ var initialization = {
         } else {
             isInitialized = true;
         }
+
+        common.consentPayloadDefaults =
+            common.consentHandler.getConsentSettings();
+        var initialConsentState = common.consentHandler.getUserConsentState();
+
+        if (common.consentPayloadDefaults && initialConsentState) {
+            var defaultConsentPayload =
+                common.consentHandler.generateConsentStatePayloadFromMappings(
+                    initialConsentState,
+                    common.consentMappings
+                );
+            common.consentPayloadAsString = JSON.stringify(
+                defaultConsentPayload
+            );
+
+            gtag('consent', 'default', defaultConsentPayload);
+        }
+
         return isInitialized;
     },
 };
@@ -102,6 +127,10 @@ function setClientId(clientId, moduleId) {
         ga4IntegrationAttributes
     );
     window.mParticle._setIntegrationDelay(moduleId, false);
+}
+
+function parseSettingsString(settingsString) {
+    return JSON.parse(settingsString.replace(/&quot;/g, '"'));
 }
 
 module.exports = initialization;

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -2340,7 +2340,7 @@ describe('Google Analytics 4 Event', function () {
             mParticle.forwarder.init(
                 {
                     conversionId: 'AW-123123123',
-                    consentMappingWeb:
+                    consentMappingSDK:
                         '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
                 },
                 reportService.cb,
@@ -2370,11 +2370,11 @@ describe('Google Analytics 4 Event', function () {
                 {
                     conversionId: 'AW-123123123',
                     enableGtag: 'True',
-                    consentMappingWeb: JSON.stringify(consentMap),
-                    adPersonalizationConsentWeb: 'Granted', // Will be overriden by User Consent State
-                    adUserDataConsentWeb: 'Granted', // Will be overriden by User Consent State
-                    adStorageConsentWeb: 'Granted',
-                    analyticsStorageConsentWeb: 'Granted',
+                    consentMappingSDK: JSON.stringify(consentMap),
+                    adPersonalizationConsentSDK: 'Granted', // Will be overriden by User Consent State
+                    adUserDataConsentSDK: 'Granted', // Will be overriden by User Consent State
+                    adStorageConsentSDK: 'Granted',
+                    analyticsStorageConsentSDK: 'Granted',
                 },
                 reportService.cb,
                 true
@@ -2406,11 +2406,11 @@ describe('Google Analytics 4 Event', function () {
                 {
                     conversionId: 'AW-123123123',
                     enableGtag: 'True',
-                    consentMappingWeb: JSON.stringify(consentMap),
-                    adStorageConsentWeb: 'Unspecified', // Will be overriden by User Consent State
-                    adUserDataConsentWeb: 'Unspecified', // Will be overriden by User Consent State
-                    adPersonalizationConsentWeb: 'Unspecified',
-                    analyticsStorageConsentWeb: 'Unspecified',
+                    consentMappingSDK: JSON.stringify(consentMap),
+                    adStorageConsentSDK: 'Unspecified', // Will be overriden by User Consent State
+                    adUserDataConsentSDK: 'Unspecified', // Will be overriden by User Consent State
+                    adPersonalizationConsentSDK: 'Unspecified',
+                    analyticsStorageConsentSDK: 'Unspecified',
                 },
                 reportService.cb,
                 true
@@ -2440,7 +2440,7 @@ describe('Google Analytics 4 Event', function () {
                 {
                     conversionId: 'AW-123123123',
                     enableGtag: 'True',
-                    consentMappingWeb: JSON.stringify(consentMap),
+                    consentMappingSDK: JSON.stringify(consentMap),
                 },
                 reportService.cb,
                 true
@@ -2604,11 +2604,11 @@ describe('Google Analytics 4 Event', function () {
                 {
                     conversionId: 'AW-123123123',
                     enableGtag: 'True',
-                    consentMappingWeb: JSON.stringify(consentMap),
-                    adPersonalizationConsentWeb: 'Granted', // Will be overriden by User Consent State
-                    adUserDataConsentWeb: 'Granted', // Will be overriden by User Consent State
-                    adStorageConsentWeb: 'Granted',
-                    analyticsStorageConsentWeb: 'Granted',
+                    consentMappingSDK: JSON.stringify(consentMap),
+                    adPersonalizationConsentSDK: 'Granted', // Will be overriden by User Consent State
+                    adUserDataConsentSDK: 'Granted', // Will be overriden by User Consent State
+                    adStorageConsentSDK: 'Granted',
+                    analyticsStorageConsentSDK: 'Granted',
                 },
                 reportService.cb,
                 true
@@ -2775,7 +2775,7 @@ describe('Google Analytics 4 Event', function () {
                 {
                     conversionId: 'AW-123123123',
                     enableGtag: 'True',
-                    consentMappingWeb: JSON.stringify(consentMap),
+                    consentMappingSDK: JSON.stringify(consentMap),
                 },
                 reportService.cb,
                 true

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -2371,10 +2371,10 @@ describe('Google Analytics 4 Event', function () {
                     conversionId: 'AW-123123123',
                     enableGtag: 'True',
                     consentMappingSDK: JSON.stringify(consentMap),
-                    adPersonalizationConsentSDK: 'Granted', // Will be overriden by User Consent State
-                    adUserDataConsentSDK: 'Granted', // Will be overriden by User Consent State
-                    adStorageConsentSDK: 'Granted',
-                    analyticsStorageConsentSDK: 'Granted',
+                    defaultAdUserDataConsentSDK: 'Granted', // Will be overriden by User Consent State
+                    defaultAdPersonalizationConsentSDK: 'Granted', // Will be overriden by User Consent State
+                    defaultAdStorageConsentSDK: 'Granted',
+                    defaultAnalyticsStorageConsentSDK: 'Granted',
                 },
                 reportService.cb,
                 true
@@ -2407,10 +2407,10 @@ describe('Google Analytics 4 Event', function () {
                     conversionId: 'AW-123123123',
                     enableGtag: 'True',
                     consentMappingSDK: JSON.stringify(consentMap),
-                    adPersonalizationConsentSDK: 'Unspecified',
-                    adUserDataConsentSDK: 'Unspecified', // Will be overriden by User Consent State
-                    adStorageConsentSDK: 'Unspecified', // Will be overriden by User Consent State
-                    analyticsStorageConsentSDK: 'Unspecified',
+                    defaultAdUserDataConsentSDK: 'Unspecified',
+                    defaultAdPersonalizationConsentSDK: 'Unspecified', // Will be overriden by User Consent State
+                    defaultAdStorageConsentSDK: 'Unspecified', // Will be overriden by User Consent State
+                    defaultAnalyticsStorageConsentSDK: 'Unspecified',
                 },
                 reportService.cb,
                 true
@@ -2605,10 +2605,10 @@ describe('Google Analytics 4 Event', function () {
                     conversionId: 'AW-123123123',
                     enableGtag: 'True',
                     consentMappingSDK: JSON.stringify(consentMap),
-                    adPersonalizationConsentSDK: 'Granted', // Will be overriden by User Consent State
-                    adUserDataConsentSDK: 'Granted', // Will be overriden by User Consent State
-                    adStorageConsentSDK: 'Granted',
-                    analyticsStorageConsentSDK: 'Granted',
+                    defaultAdUserDataConsentSDK: 'Granted', // Will be overriden by User Consent State
+                    defaultAdPersonalizationConsentSDK: 'Granted', // Will be overriden by User Consent State
+                    defaultAdStorageConsentSDK: 'Granted',
+                    defaultAnalyticsStorageConsentSDK: 'Granted',
                 },
                 reportService.cb,
                 true
@@ -2912,10 +2912,10 @@ describe('Google Analytics 4 Event', function () {
                 {
                     conversionId: 'AW-123123123',
                     enableGtag: 'True',
-                    adUserDataConsentSDK: 'Granted',
-                    adPersonalizationConsentSDK: 'Denied',
-                    adStorageConsentSDK: 'Granted',
-                    analyticsStorageConsentSDK: 'Denied',
+                    defaultAdUserDataConsentSDK: 'Granted',
+                    defaultAdPersonalizationConsentSDK: 'Denied',
+                    defaultAdStorageConsentSDK: 'Granted',
+                    defaultAnalyticsStorageConsentSDK: 'Denied',
                 },
                 reportService.cb,
                 true

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -2340,7 +2340,7 @@ describe('Google Analytics 4 Event', function () {
             mParticle.forwarder.init(
                 {
                     conversionId: 'AW-123123123',
-                    consentMapping:
+                    consentMappingSDK:
                         '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
                 },
                 reportService.cb,
@@ -2370,9 +2370,9 @@ describe('Google Analytics 4 Event', function () {
                 {
                     conversionId: 'AW-123123123',
                     enableGtag: 'True',
-                    consentMapping: JSON.stringify(consentMap),
-                    adPersonalizationConsent: 'Granted', // Will be overriden by User Consent State
-                    adUserDataConsent: 'Granted', // Will be overriden by User Consent State
+                    consentMappingSDK: JSON.stringify(consentMap),
+                    adPersonalizationConsentSDK: 'Granted', // Will be overriden by User Consent State
+                    adUserDataConsentSDK: 'Granted', // Will be overriden by User Consent State
                     adStorageConsentSDK: 'Granted',
                     analyticsStorageConsentSDK: 'Granted',
                 },
@@ -2406,9 +2406,9 @@ describe('Google Analytics 4 Event', function () {
                 {
                     conversionId: 'AW-123123123',
                     enableGtag: 'True',
-                    consentMapping: JSON.stringify(consentMap),
-                    adPersonalizationConsent: 'Unspecified',
-                    adUserDataConsent: 'Unspecified', // Will be overriden by User Consent State
+                    consentMappingSDK: JSON.stringify(consentMap),
+                    adPersonalizationConsentSDK: 'Unspecified',
+                    adUserDataConsentSDK: 'Unspecified', // Will be overriden by User Consent State
                     adStorageConsentSDK: 'Unspecified', // Will be overriden by User Consent State
                     analyticsStorageConsentSDK: 'Unspecified',
                 },
@@ -2440,7 +2440,7 @@ describe('Google Analytics 4 Event', function () {
                 {
                     conversionId: 'AW-123123123',
                     enableGtag: 'True',
-                    consentMapping: JSON.stringify(consentMap),
+                    consentMappingSDK: JSON.stringify(consentMap),
                 },
                 reportService.cb,
                 true
@@ -2604,9 +2604,9 @@ describe('Google Analytics 4 Event', function () {
                 {
                     conversionId: 'AW-123123123',
                     enableGtag: 'True',
-                    consentMapping: JSON.stringify(consentMap),
-                    adPersonalizationConsent: 'Granted', // Will be overriden by User Consent State
-                    adUserDataConsent: 'Granted', // Will be overriden by User Consent State
+                    consentMappingSDK: JSON.stringify(consentMap),
+                    adPersonalizationConsentSDK: 'Granted', // Will be overriden by User Consent State
+                    adUserDataConsentSDK: 'Granted', // Will be overriden by User Consent State
                     adStorageConsentSDK: 'Granted',
                     analyticsStorageConsentSDK: 'Granted',
                 },
@@ -2775,7 +2775,7 @@ describe('Google Analytics 4 Event', function () {
                 {
                     conversionId: 'AW-123123123',
                     enableGtag: 'True',
-                    consentMapping: JSON.stringify(consentMap),
+                    consentMappingSDK: JSON.stringify(consentMap),
                 },
                 reportService.cb,
                 true
@@ -2912,8 +2912,8 @@ describe('Google Analytics 4 Event', function () {
                 {
                     conversionId: 'AW-123123123',
                     enableGtag: 'True',
-                    adUserDataConsent: 'Granted',
-                    adPersonalizationConsent: 'Denied',
+                    adUserDataConsentSDK: 'Granted',
+                    adPersonalizationConsentSDK: 'Denied',
                     adStorageConsentSDK: 'Granted',
                     analyticsStorageConsentSDK: 'Denied',
                 },

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -112,6 +112,24 @@ describe('Google Analytics 4 Event', function () {
                         },
                     };
                 },
+                getConsentState: function () {
+                    return {
+                        getGDPRConsentState: function () {
+                            return {
+                                some_consent: {
+                                    Consented: false,
+                                    Timestamp: 1,
+                                    Document: 'some_consent',
+                                },
+                                test_consent: {
+                                    Consented: false,
+                                    Timestamp: 1,
+                                    Document: 'test_consent',
+                                },
+                            };
+                        },
+                    };
+                },
             };
         },
     };
@@ -2283,6 +2301,535 @@ describe('Google Analytics 4 Event', function () {
 
                 done();
             });
+        });
+    });
+
+    describe('Consent State', () => {
+        var consentMap = [
+            {
+                jsmap: null,
+                map: 'some_consent',
+                maptype: 'ConsentPurposes',
+                value: 'ad_user_data',
+            },
+            {
+                jsmap: null,
+                map: 'storage_consent',
+                maptype: 'ConsentPurposes',
+                value: 'analytics_storage',
+            },
+            {
+                jsmap: null,
+                map: 'other_test_consent',
+                maptype: 'ConsentPurposes',
+                value: 'ad_storage',
+            },
+            {
+                jsmap: null,
+                map: 'test_consent',
+                maptype: 'ConsentPurposes',
+                value: 'ad_personalization',
+            },
+        ];
+
+        beforeEach(function () {
+            window.dataLayer = [];
+        });
+
+        it('should construct a Default Consent State Payload from Mappings', (done) => {
+            mParticle.forwarder.init(
+                {
+                    conversionId: 'AW-123123123',
+                    consentMappingWeb:
+                        '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
+                },
+                reportService.cb,
+                true
+            );
+
+            var expectedDataLayer = [
+                'consent',
+                'default',
+                {
+                    ad_user_data: 'denied',
+                    ad_personalization: 'denied',
+                },
+            ];
+
+            // Initial elements of Data Layer are setup for gtag.
+            // Consent state should be on the bottom
+            window.dataLayer.length.should.eql(4);
+            window.dataLayer[3][0].should.equal('consent');
+            window.dataLayer[3][1].should.equal('default');
+            window.dataLayer[3][2].should.deepEqual(expectedDataLayer[2]);
+            done();
+        });
+
+        it('should merge Consent Setting Defaults with User Consent State to construct a Default Consent State', (done) => {
+            mParticle.forwarder.init(
+                {
+                    conversionId: 'AW-123123123',
+                    enableGtag: 'True',
+                    consentMappingWeb: JSON.stringify(consentMap),
+                    adPersonalizationConsentWeb: 'Granted', // Will be overriden by User Consent State
+                    adUserDataConsentWeb: 'Granted', // Will be overriden by User Consent State
+                    adStorageConsentWeb: 'Granted',
+                    analyticsStorageConsentWeb: 'Granted',
+                },
+                reportService.cb,
+                true
+            );
+
+            var expectedDataLayer = [
+                'consent',
+                'default',
+                {
+                    ad_personalization: 'denied', // From User Consent State
+                    ad_user_data: 'denied', // From User Consent State
+                    ad_storage: 'granted', // From Consent Settings
+                    analytics_storage: 'granted', // From Consent Settings
+                },
+            ];
+
+            // Initial elements of Data Layer are setup for gtag.
+            // Consent state should be on the bottom
+            window.dataLayer.length.should.eql(4);
+            window.dataLayer[3][0].should.equal('consent');
+            window.dataLayer[3][1].should.equal('default');
+            window.dataLayer[3][2].should.deepEqual(expectedDataLayer[2]);
+
+            done();
+        });
+
+        it('should ignore Unspecified Consent Settings if NOT explicitely defined in Consent State', (done) => {
+            mParticle.forwarder.init(
+                {
+                    conversionId: 'AW-123123123',
+                    enableGtag: 'True',
+                    consentMappingWeb: JSON.stringify(consentMap),
+                    adStorageConsentWeb: 'Unspecified', // Will be overriden by User Consent State
+                    adUserDataConsentWeb: 'Unspecified', // Will be overriden by User Consent State
+                    adPersonalizationConsentWeb: 'Unspecified',
+                    analyticsStorageConsentWeb: 'Unspecified',
+                },
+                reportService.cb,
+                true
+            );
+
+            var expectedDataLayer = [
+                'consent',
+                'default',
+                {
+                    ad_personalization: 'denied', // From User Consent State
+                    ad_user_data: 'denied', // From User Consent State
+                },
+            ];
+
+            // Initial elements of Data Layer are setup for gtag.
+            // Consent state should be on the bottom
+            window.dataLayer.length.should.eql(4);
+            window.dataLayer[3][0].should.equal('consent');
+            window.dataLayer[3][1].should.equal('default');
+            window.dataLayer[3][2].should.deepEqual(expectedDataLayer[2]);
+
+            done();
+        });
+
+        it('should construct a Consent State Update Payload when consent changes', (done) => {
+            mParticle.forwarder.init(
+                {
+                    conversionId: 'AW-123123123',
+                    enableGtag: 'True',
+                    consentMappingWeb: JSON.stringify(consentMap),
+                },
+                reportService.cb,
+                true
+            );
+
+            var expectedDataLayerBefore = [
+                'consent',
+                'update',
+                {
+                    ad_user_data: 'denied',
+                    ad_personalization: 'denied',
+                },
+            ];
+
+            // Initial elements of Data Layer are setup for gtag.
+            // Consent state should be on the bottom
+            window.dataLayer.length.should.eql(4);
+            window.dataLayer[3][0].should.equal('consent');
+            window.dataLayer[3][1].should.equal('default');
+            window.dataLayer[3][2].should.deepEqual(expectedDataLayerBefore[2]);
+
+            mParticle.forwarder.process({
+                EventName: 'Homepage',
+                EventDataType: MessageType.PageEvent,
+                EventCategory: EventType.Navigation,
+                EventAttributes: {
+                    showcase: 'something',
+                    test: 'thisoneshouldgetmapped',
+                    mp: 'rock',
+                },
+                ConsentState: {
+                    getGDPRConsentState: function () {
+                        return {
+                            some_consent: {
+                                Consented: true,
+                                Timestamp: Date.now(),
+                                Document: 'some_consent',
+                            },
+                            ignored_consent: {
+                                Consented: false,
+                                Timestamp: Date.now(),
+                                Document: 'ignored_consent',
+                            },
+                            test_consent: {
+                                Consented: true,
+                                Timestamp: Date.now(),
+                                Document: 'test_consent',
+                            },
+                        };
+                    },
+
+                    getCCPAConsentState: function () {
+                        return {
+                            data_sale_opt_out: {
+                                Consented: false,
+                                Timestamp: Date.now(),
+                                Document: 'some_consent',
+                            },
+                        };
+                    },
+                },
+            });
+
+            var expectedDataLayerAfter = [
+                'consent',
+                'update',
+                {
+                    ad_user_data: 'granted',
+                    ad_personalization: 'granted',
+                },
+            ];
+
+            // Initial elements of Data Layer are setup for gtag.
+            // Consent Default is index 3
+            // Consent Update is index 4
+            // Event is index 5
+            window.dataLayer.length.should.eql(6);
+            window.dataLayer[4][0].should.equal('consent');
+            window.dataLayer[4][1].should.equal('update');
+            window.dataLayer[4][2].should.deepEqual(expectedDataLayerAfter[2]);
+
+            mParticle.forwarder.process({
+                EventName: 'Homepage',
+                EventDataType: MessageType.PageEvent,
+                EventCategory: EventType.Navigation,
+                EventAttributes: {
+                    showcase: 'something',
+                    test: 'thisoneshouldgetmapped',
+                    mp: 'rock',
+                },
+                ConsentState: {
+                    getGDPRConsentState: function () {
+                        return {
+                            some_consent: {
+                                Consented: true,
+                                Timestamp: Date.now(),
+                                Document: 'some_consent',
+                            },
+                            ignored_consent: {
+                                Consented: false,
+                                Timestamp: Date.now(),
+                                Document: 'ignored_consent',
+                            },
+                            test_consent: {
+                                Consented: true,
+                                Timestamp: Date.now(),
+                                Document: 'test_consent',
+                            },
+                            other_test_consent: {
+                                Consented: true,
+                                Timestamp: Date.now(),
+                                Document: 'other_test_consent',
+                            },
+                            storage_consent: {
+                                Consented: false,
+                                Timestamp: Date.now(),
+                                Document: 'storage_consent',
+                            },
+                        };
+                    },
+
+                    getCCPAConsentState: function () {
+                        return {
+                            data_sale_opt_out: {
+                                Consented: false,
+                                Timestamp: Date.now(),
+                                Document: 'data_sale_opt_out',
+                            },
+                        };
+                    },
+                },
+            });
+
+            var expectedDataLayerFinal = [
+                'consent',
+                'update',
+                {
+                    ad_personalization: 'granted',
+                    ad_storage: 'granted',
+                    ad_user_data: 'granted',
+                    analytics_storage: 'denied',
+                },
+            ];
+
+            // Initial elements of Data Layer are setup for gtag.
+            // Consent Default is index 3
+            // Consent Update is index 4
+            // Event is index 5
+            // Consent Update #2 is index 6
+            // Event #2 is index 7
+            window.dataLayer.length.should.eql(8);
+            window.dataLayer[6][0].should.equal('consent');
+            window.dataLayer[6][1].should.equal('update');
+            window.dataLayer[6][2].should.deepEqual(expectedDataLayerFinal[2]);
+
+            done();
+        });
+
+        it('should construct a Consent State Update Payload with Consent Setting Defaults when consent changes', (done) => {
+            mParticle.forwarder.init(
+                {
+                    conversionId: 'AW-123123123',
+                    enableGtag: 'True',
+                    consentMappingWeb: JSON.stringify(consentMap),
+                    adPersonalizationConsentWeb: 'Granted', // Will be overriden by User Consent State
+                    adUserDataConsentWeb: 'Granted', // Will be overriden by User Consent State
+                    adStorageConsentWeb: 'Granted',
+                    analyticsStorageConsentWeb: 'Granted',
+                },
+                reportService.cb,
+                true
+            );
+
+            var expectedDataLayerBefore = [
+                'consent',
+                'update',
+                {
+                    ad_personalization: 'denied', // From User Consent State
+                    ad_user_data: 'denied', // From User Consent State
+                    ad_storage: 'granted', // From Consent Settings
+                    analytics_storage: 'granted', // From Consent Settings
+                },
+            ];
+
+            // Initial elements of Data Layer are setup for gtag.
+            // Consent state should be on the bottom
+            window.dataLayer.length.should.eql(4);
+            window.dataLayer[3][0].should.equal('consent');
+            window.dataLayer[3][1].should.equal('default');
+            window.dataLayer[3][2].should.deepEqual(expectedDataLayerBefore[2]);
+
+            mParticle.forwarder.process({
+                EventName: 'Homepage',
+                EventDataType: MessageType.PageEvent,
+                EventCategory: EventType.Navigation,
+                EventAttributes: {
+                    showcase: 'something',
+                    test: 'thisoneshouldgetmapped',
+                    mp: 'rock',
+                },
+                ConsentState: {
+                    getGDPRConsentState: function () {
+                        return {
+                            some_consent: {
+                                Consented: true,
+                                Timestamp: Date.now(),
+                                Document: 'some_consent',
+                            },
+                            ignored_consent: {
+                                Consented: false,
+                                Timestamp: Date.now(),
+                                Document: 'ignored_consent',
+                            },
+                            test_consent: {
+                                Consented: true,
+                                Timestamp: Date.now(),
+                                Document: 'test_consent',
+                            },
+                        };
+                    },
+
+                    getCCPAConsentState: function () {
+                        return {
+                            data_sale_opt_out: {
+                                Consented: false,
+                                Timestamp: Date.now(),
+                                Document: 'data_sale_opt_out',
+                            },
+                        };
+                    },
+                },
+            });
+
+            var expectedDataLayerAfter = [
+                'consent',
+                'update',
+                {
+                    ad_personalization: 'granted', // From Event Consent State Change
+                    ad_user_data: 'granted', // From Event Consent State Change
+                    ad_storage: 'granted', // From Consent Settings
+                    analytics_storage: 'granted', // From Consent Settings
+                },
+            ];
+
+            // Initial elements of Data Layer are setup for gtag.
+            // Consent Default is index 3
+            // Consent Update is index 4
+            // Event is index 5
+            window.dataLayer.length.should.eql(6);
+            window.dataLayer[4][0].should.equal('consent');
+            window.dataLayer[4][1].should.equal('update');
+            window.dataLayer[4][2].should.deepEqual(expectedDataLayerAfter[2]);
+
+            mParticle.forwarder.process({
+                EventName: 'Homepage',
+                EventDataType: MessageType.PageEvent,
+                EventCategory: EventType.Navigation,
+                EventAttributes: {
+                    showcase: 'something',
+                    test: 'thisoneshouldgetmapped',
+                    mp: 'rock',
+                },
+                ConsentState: {
+                    getGDPRConsentState: function () {
+                        return {
+                            some_consent: {
+                                Consented: true,
+                                Timestamp: Date.now(),
+                                Document: 'some_consent',
+                            },
+                            ignored_consent: {
+                                Consented: false,
+                                Timestamp: Date.now(),
+                                Document: 'ignored_consent',
+                            },
+                            test_consent: {
+                                Consented: true,
+                                Timestamp: Date.now(),
+                                Document: 'test_consent',
+                            },
+                            other_test_consent: {
+                                Consented: true,
+                                Timestamp: Date.now(),
+                                Document: 'other_test_consent',
+                            },
+                            storage_consent: {
+                                Consented: false,
+                                Timestamp: Date.now(),
+                                Document: 'storage_consent',
+                            },
+                        };
+                    },
+
+                    getCCPAConsentState: function () {
+                        return {
+                            data_sale_opt_out: {
+                                Consented: false,
+                                Timestamp: Date.now(),
+                                Document: 'data_sale_opt_out',
+                            },
+                        };
+                    },
+                },
+            });
+
+            var expectedDataLayerFinal = [
+                'consent',
+                'update',
+                {
+                    ad_personalization: 'granted', // From Previous Event State Change
+                    ad_storage: 'granted', // From Previous Event State Change
+                    ad_user_data: 'granted', // From Consent Settings
+                    analytics_storage: 'denied', // From FinalEvent Consent State Change
+                },
+            ];
+
+            // Initial elements of Data Layer are setup for gtag.
+            // Consent Default is index 3
+            // Consent Update is index 4
+            // Event is index 5
+            // Consent Update #2 is index 6
+            // Event #2 is index 7
+            window.dataLayer.length.should.eql(8);
+            window.dataLayer[6][0].should.equal('consent');
+            window.dataLayer[6][1].should.equal('update');
+            window.dataLayer[6][2].should.deepEqual(expectedDataLayerFinal[2]);
+            done();
+        });
+
+        it('should NOT construct a Consent State Update Payload if consent DOES NOT change', (done) => {
+            mParticle.forwarder.init(
+                {
+                    conversionId: 'AW-123123123',
+                    enableGtag: 'True',
+                    consentMappingWeb: JSON.stringify(consentMap),
+                },
+                reportService.cb,
+                true
+            );
+
+            var expectedDataLayerBefore = [
+                'consent',
+                'update',
+                {
+                    ad_user_data: 'denied',
+                    ad_personalization: 'denied',
+                },
+            ];
+
+            // Initial elements of Data Layer are setup for gtag.
+            // Consent state should be on the bottom
+            window.dataLayer.length.should.eql(4);
+            window.dataLayer[3][0].should.equal('consent');
+            window.dataLayer[3][1].should.equal('default');
+            window.dataLayer[3][2].should.deepEqual(expectedDataLayerBefore[2]);
+
+            mParticle.forwarder.process({
+                EventName: 'Homepage',
+                EventDataType: MessageType.PageEvent,
+                EventCategory: EventType.Navigation,
+                EventAttributes: {
+                    showcase: 'something',
+                    test: 'thisoneshouldgetmapped',
+                    mp: 'rock',
+                },
+                ConsentState: {
+                    getGDPRConsentState: function () {
+                        return {
+                            some_consent: {
+                                Consented: false,
+                                Timestamp: Date.now(),
+                                Document: 'some_consent',
+                            },
+                            test_consent: {
+                                Consented: false,
+                                Timestamp: Date.now(),
+                                Document: 'test_consent',
+                            },
+                        };
+                    },
+                },
+            });
+
+            // Last Element of data layer should only contain actual event
+            window.dataLayer.length.should.eql(5);
+            window.dataLayer[4][0].should.equal('event');
+            window.dataLayer[4][1].should.equal('Homepage');
+
+            done();
         });
     });
 });


### PR DESCRIPTION
## Summary
 - Adds a check to initForwarder and processEvents so that if the consent state changes, we alert Google via their `gtag` as per their [Consent Mode Documention](https://developers.google.com/tag-platform/security/guides/consent)

## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Set up Consent Mapping and Privacy Configuration via the mParticle UI
 - Using our [Data Privacy Controls] instructions, toggle some of the mapped consent states via the developer console
 - Verify that mapped events appear in `window.dataLayer` via browser developer console as updates with updated values

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-6155
Mirrors similar update to [Adwords](https://github.com/mparticle-integrations/mparticle-javascript-integration-adwords/pull/52)