### PR TITLE
fix: exceptional max attribute length and page_referrer flag addition

### DIFF
--- a/packages/GA4Client/src/common.js
+++ b/packages/GA4Client/src/common.js
@@ -17,6 +17,10 @@ var USER_ATTRIBUTE_VALUE_MAX_LENGTH = 36;
 
 var PRODUCT_ATTRIBUTE_MAX_NUMBER = 10;
 
+var PAGE_TITLE_KEY = 'page_title';
+var PAGE_LOCATION_KEY = 'page_location';
+var PAGE_REFERRER_KEY = 'page_referrer';
+
 var RESERVED_PRODUCT_KEYS = [
     'item_category',
     'item_category2',
@@ -70,29 +74,21 @@ Common.prototype.truncateAttributes = function (
     if (!isEmpty(attributes)) {
         Object.keys(attributes).forEach(function (attribute) {
             var key = truncateString(attribute, keyLimit);
-            var val;
+            var valueLimitOverride;
             switch (key) {
-                case 'page_title':
-                    val = truncateString(
-                        attributes[attribute],
-                        PAGE_TITLE_MAX_LENGTH
-                    );
+                case PAGE_TITLE_KEY:
+                    valueLimitOverride = PAGE_TITLE_MAX_LENGTH;
                     break;
-                case 'page_referrer':
-                    val = truncateString(
-                        attributes[attribute],
-                        PAGE_REFERRER_MAX_LENGTH
-                    );
+                case PAGE_REFERRER_KEY:
+                    valueLimitOverride = PAGE_REFERRER_MAX_LENGTH;
                     break;
-                case 'page_location':
-                    val = truncateString(
-                        attributes[attribute],
-                        PAGE_LOCATION_MAX_LENGTH
-                    );
+                case PAGE_LOCATION_KEY:
+                    valueLimitOverride = PAGE_LOCATION_MAX_LENGTH;
                     break;
                 default:
-                    val = truncateString(attributes[attribute], valueLimit);
+                    valueLimitOverride = valueLimit;
             }
+            var val = truncateString(attributes[attribute], valueLimitOverride);
             truncatedAttributes[key] = val;
         });
     }

--- a/packages/GA4Client/src/common.js
+++ b/packages/GA4Client/src/common.js
@@ -8,6 +8,9 @@ var EVENT_NAME_MAX_LENGTH = 40;
 var EVENT_ATTRIBUTE_KEY_MAX_LENGTH = 40;
 var EVENT_ATTRIBUTE_VAL_MAX_LENGTH = 100;
 var EVENT_ATTRIBUTE_MAX_NUMBER = 100;
+var PAGE_TITLE_MAX_LENGTH = 300;
+var PAGE_REFERRER_MAX_LENGTH = 420;
+var PAGE_LOCATION_MAX_LENGTH = 1000;
 
 var USER_ATTRIBUTE_KEY_MAX_LENGTH = 24;
 var USER_ATTRIBUTE_VALUE_MAX_LENGTH = 36;
@@ -67,7 +70,29 @@ Common.prototype.truncateAttributes = function (
     if (!isEmpty(attributes)) {
         Object.keys(attributes).forEach(function (attribute) {
             var key = truncateString(attribute, keyLimit);
-            var val = truncateString(attributes[attribute], valueLimit);
+            var val;
+            switch (key) {
+                case 'page_title':
+                    val = truncateString(
+                        attributes[attribute],
+                        PAGE_TITLE_MAX_LENGTH
+                    );
+                    break;
+                case 'page_referrer':
+                    val = truncateString(
+                        attributes[attribute],
+                        PAGE_REFERRER_MAX_LENGTH
+                    );
+                    break;
+                case 'page_location':
+                    val = truncateString(
+                        attributes[attribute],
+                        PAGE_LOCATION_MAX_LENGTH
+                    );
+                    break;
+                default:
+                    val = truncateString(attributes[attribute], valueLimit);
+            }
             truncatedAttributes[key] = val;
         });
     }

--- a/packages/GA4Client/src/event-handler.js
+++ b/packages/GA4Client/src/event-handler.js
@@ -69,13 +69,15 @@ EventHandler.prototype.logError = function () {
 EventHandler.prototype.logPageView = function (event) {
     var TITLE = 'GA4.Title';
     var LOCATION = 'GA4.Location';
+    var REFERRER = 'GA4.Referrer';
 
     // These are being included for backwards compatibility from the legacy Google Analytics custom flags
     var LEGACY_GA_TITLE = 'Google.Title';
     var LEGACY_GA_LOCATION = 'Google.Location';
 
     var pageLocation = location.href,
-        pageTitle = document.title;
+        pageTitle = document.title,
+        pageReferrer = document.referrer;
 
     if (event.CustomFlags) {
         if (event.CustomFlags.hasOwnProperty(TITLE)) {
@@ -89,12 +91,17 @@ EventHandler.prototype.logPageView = function (event) {
         } else if (event.CustomFlags.hasOwnProperty(LEGACY_GA_LOCATION)) {
             pageLocation = event.CustomFlags[LEGACY_GA_LOCATION];
         }
+
+        if (event.CustomFlags.hasOwnProperty(REFERRER)) {
+            pageReferrer = event.CustomFlags[REFERRER];
+        }
     }
 
     var eventAttributes = this.common.mergeObjects(
         {
             page_title: pageTitle,
             page_location: pageLocation,
+            page_referrer: pageReferrer,
         },
         event.EventAttributes
     );

--- a/packages/GA4Client/src/event-handler.js
+++ b/packages/GA4Client/src/event-handler.js
@@ -74,10 +74,11 @@ EventHandler.prototype.logPageView = function (event) {
     // These are being included for backwards compatibility from the legacy Google Analytics custom flags
     var LEGACY_GA_TITLE = 'Google.Title';
     var LEGACY_GA_LOCATION = 'Google.Location';
+    var LEGACY_GA_REFERRER = 'Google.DocumentReferrer';
 
-    var pageLocation = location.href,
-        pageTitle = document.title,
-        pageReferrer = document.referrer;
+    var pageLocation = location.href;
+    var pageTitle = document.title;
+    var pageReferrer = document.referrer;
 
     if (event.CustomFlags) {
         if (event.CustomFlags.hasOwnProperty(TITLE)) {
@@ -94,6 +95,8 @@ EventHandler.prototype.logPageView = function (event) {
 
         if (event.CustomFlags.hasOwnProperty(REFERRER)) {
             pageReferrer = event.CustomFlags[REFERRER];
+        } else if (event.CustomFlags.hasOwnProperty(LEGACY_GA_REFERRER)) {
+            pageReferrer = event.CustomFlags[LEGACY_GA_REFERRER];
         }
     }
 

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -1639,6 +1639,7 @@ describe('Google Analytics 4 Event', function () {
                     CustomFlags: {
                         'Google.Title': 'Foo Page Title',
                         'Google.Location': '/foo',
+                        'Google.DocumentReferrer': 'Foo Page Referrer'
                     },
                 });
                 var result = [
@@ -1647,7 +1648,7 @@ describe('Google Analytics 4 Event', function () {
                     {
                         page_title: 'Foo Page Title',
                         page_location: '/foo',
-                        page_referrer: document.referrer,
+                        page_referrer: 'Foo Page Referrer',
                         send_to: 'testMeasurementId',
                     },
                 ];

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -1522,6 +1522,7 @@ describe('Google Analytics 4 Event', function () {
                     {
                         page_title: 'Mocha Tests',
                         page_location: location.href,
+                        page_referrer: document.referrer,
                         send_to: 'testMeasurementId',
                     },
                 ];
@@ -1541,6 +1542,7 @@ describe('Google Analytics 4 Event', function () {
                     CustomFlags: {
                         'GA4.Title': 'Foo Page Title',
                         'GA4.Location': '/foo',
+                        'GA4.Referrer': 'Foo Page Referrer'
                     },
                 });
 
@@ -1550,6 +1552,7 @@ describe('Google Analytics 4 Event', function () {
                     {
                         page_title: 'Foo Page Title',
                         page_location: '/foo',
+                        page_referrer: 'Foo Page Referrer',
                         eventKey1: 'test1',
                         eventKey2: 'test2',
                         send_to: 'testMeasurementId',
@@ -1644,6 +1647,7 @@ describe('Google Analytics 4 Event', function () {
                     {
                         page_title: 'Foo Page Title',
                         page_location: '/foo',
+                        page_referrer: document.referrer,
                         send_to: 'testMeasurementId',
                     },
                 ];
@@ -1660,6 +1664,7 @@ describe('Google Analytics 4 Event', function () {
                     CustomFlags: {
                         'GA4.Title': 'Foo Page Title',
                         'GA4.Location': '/foo',
+                        'GA4.Referrer': 'Foo Page Referrer'
                     },
                 });
 
@@ -1669,6 +1674,7 @@ describe('Google Analytics 4 Event', function () {
                     {
                         page_title: 'Foo Page Title',
                         page_location: '/foo',
+                        page_referrer: 'Foo Page Referrer',
                         send_to: 'testMeasurementId',
                     },
                 ];
@@ -1676,6 +1682,42 @@ describe('Google Analytics 4 Event', function () {
 
                 done();
             });
+
+            it('should log page view with truncated GA custom flags', function (done) {
+                function generateValue(length) {
+                    var value = ''
+                    for (let i = 0; i < length; i++) {
+                        value += 'a'
+                    }
+                    return value
+                }
+
+                mParticle.forwarder.process({
+                    EventDataType: MessageType.PageView,
+                    EventName: 'test name',
+                    EventAttributes: {},
+                    CustomFlags: {
+                        'GA4.Title': generateValue(305), // Max page_title length is 300 for GA4
+                        'GA4.Location': generateValue(1005), // Max page_location length is 1000 for GA4
+                        'GA4.Referrer': generateValue(425) // Max page_referrer length is 420 for GA4
+                    },
+                });
+
+                var result = [
+                    'event',
+                    'page_view',
+                    {
+                        page_title: generateValue(300),
+                        page_location: generateValue(1000),
+                        page_referrer: generateValue(420),
+                        send_to: 'testMeasurementId',
+                    },
+                ];
+
+                window.dataLayer[0].should.eql(result);
+
+                done();
+            }) 
 
             describe('limit event attributes', function () {
                 // 101 event attribute keys because the limit is 100


### PR DESCRIPTION
## Summary
This PR covers a bug fix and a feature request:
- fix: Google has a couple of exceptions for some attributes/params max lengths such as page_title (300 chars), page_location (1000 chars), page_referrer (420 chars) (doc [here](https://support.google.com/analytics/answer/9267744?hl=en)) while we automatically truncate every attribute and custom flag to 100 chars, this resulted in an issue where the customer reported missing attribution on the Google Ads side due to this issue.
- feature request: GA4 has a special param page_referrer that is similar to page_title and page_location and the request here is to include it as a custom flag to map into it. I included the new flag `GA4.Referrer` for the mapping. This flag has no legacy backwards compatibility as it wasn't available for GA Universal as you can see in the screenshot below taken from this GA support doc [here](https://support.google.com/analytics/answer/9964640?hl=en#zippy=%2Cin-this-article)
<img width="622" alt="Screenshot 2024-04-30 at 9 50 08 AM" src="https://github.com/mparticle-integrations/mparticle-javascript-integration-google-analytics-4/assets/96316894/e5202e25-78f2-472c-ad8c-32b1816d7aa4">

Also, just like the flags GA4.Location (page_location) and GA4.Title (page_title) I did include it's default value in case it was not provided by the customer which in this case is the `document.referrer` as mentioned here in this google support [doc](https://developers.google.com/analytics/devguides/collection/ga4/reference/config#page_referrer)

## Testing Plan
- Included new and modified some unit tests and it passed as expected.
- tested E2E using local overrides with the new code implemented and it worked as expected

## Master Issue
Closes https://mparticle-eng.atlassian.net/browse/PRODRDMP-6731 and https://mparticle.lightning.force.com/lightning/r/Gap_Opportunity_Connector__c/a0uRg000001RWHlIAO/view
