### PR TITLE
fix: forward Impressions and Promotions custom attributes

### DIFF
--- a/packages/GA4Client/src/commerce-handler.js
+++ b/packages/GA4Client/src/commerce-handler.js
@@ -215,6 +215,11 @@ CommerceHandler.prototype.logPromotionEvent = function (event) {
         event.PromotionAction.PromotionList.forEach(function (promotion) {
             ga4CommerceEventParameters = buildPromotion(promotion);
 
+            ga4CommerceEventParameters = self.common.mergeObjects(
+                ga4CommerceEventParameters,
+                self.common.limitEventAttributes(event.EventAttributes)
+            );
+
             self.sendCommerceEventToGA4(
                 mapGA4EcommerceEventName(event),
                 ga4CommerceEventParameters
@@ -239,6 +244,11 @@ CommerceHandler.prototype.logImpressionEvent = function (event, affiliation) {
             ga4CommerceEventParameters = parseImpression(
                 impression,
                 affiliation
+            );
+
+            ga4CommerceEventParameters = self.common.mergeObjects(
+                ga4CommerceEventParameters,
+                self.common.limitEventAttributes(event.EventAttributes)
             );
 
             self.sendCommerceEventToGA4(

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -2385,6 +2385,186 @@ describe('Google Analytics 4 Event', function () {
 
                 done();
             });
+
+            it('should include impression event custom attributes on GA4 view_item_list event', function(done) {
+                mParticle.forwarder.process({
+                    CurrencyCode: 'USD',
+                    EventName: 'Test Purchase Event',
+                    EventDataType: MessageType.Commerce,
+                    EventCategory: CommerceEventType.ProductImpression,
+                    EventAttributes: {"foo": "bar"},
+                    ProductImpressions: [
+                        {
+                            // TODO: Does this map to the name or id of the impression?
+                            ProductImpressionList: 'Related Products',
+                            ProductList: [
+                                {
+                                    Attributes: {
+                                        eventMetric1: 'metric2',
+                                        journeyType: 'testjourneytype1',
+                                    },
+                                    Brand: 'brand',
+                                    Category: 'category',
+                                    CouponCode: 'coupon',
+                                    Name: 'iphone',
+                                    Position: 1,
+                                    Price: 999,
+                                    Quantity: 1,
+                                    Sku: 'iphoneSKU',
+                                    TotalAmount: 999,
+                                    Variant: 'variant',
+                                    'test 1': 'test1',
+                                    'test??2': 'test2',
+                                    '3!test 3': 'test3',
+                                },
+                                {
+                                    Attributes: {
+                                        eventMetric1: 'metric1',
+                                        journeyType: 'testjourneytype2',
+                                    },
+                                    Brand: 'brand',
+                                    Category: 'category',
+                                    CouponCode: 'coupon',
+                                    Name: 'iphone',
+                                    Position: 1,
+                                    Price: 999,
+                                    Quantity: 1,
+                                    Sku: 'iphoneSKU',
+                                    TotalAmount: 999,
+                                    Variant: 'variant',
+                                },
+                            ],
+                            TaxAmount: 40,
+                            ShippingAmount: 10,
+                            CouponCode: 'couponCode',
+                        },
+                    ],
+                });
+
+                var result = [
+                    'event',
+                    'view_item_list',
+                    {
+                        item_list_id: 'Related Products',
+                        item_list_name: 'Related Products',
+                        items: [
+                            {
+                                eventMetric1: 'metric2',
+                                journeyType: 'testjourneytype1',
+                                coupon: 'coupon',
+                                item_brand: 'brand',
+                                item_category: 'category',
+                                item_id: 'iphoneSKU',
+                                item_name: 'iphone',
+                                item_variant: 'variant',
+                                position: 1,
+                                price: 999,
+                                quantity: 1,
+                                total_amount: 999,
+                                test_1: 'test1',
+                                test__2: 'test2',
+                                test_3: 'test3',
+                            },
+                            {
+                                eventMetric1: 'metric1',
+                                journeyType: 'testjourneytype2',
+                                coupon: 'coupon',
+                                item_brand: 'brand',
+                                item_category: 'category',
+                                item_id: 'iphoneSKU',
+                                item_name: 'iphone',
+                                item_variant: 'variant',
+                                position: 1,
+                                price: 999,
+                                quantity: 1,
+                                total_amount: 999,
+                            },
+                        ],
+                        foo: "bar",
+                        send_to: 'testMeasurementId'
+                    },
+                ];
+
+                window.dataLayer[0].should.eql(result);
+
+                done();
+            })
+
+            it('should include promotion click event custom attributes on GA4 select_promotion event', function (done) {
+                mParticle.forwarder.process({
+                    CurrencyCode: 'USD',
+                    EventName: 'Test Purchase Event',
+                    EventDataType: MessageType.Commerce,
+                    EventCategory: CommerceEventType.PromotionClick,
+                    EventAttributes: {"foo": "bar"},
+                    PromotionAction: {
+                        PromotionActionType: PromotionActionType.PromotionClick,
+                        PromotionList: [
+                            {
+                                Id: 'P_12345',
+                                Name: 'Summer Sale Banner',
+                                Creative: 'Summer Sale',
+                                Position: 'featured_app_1',
+                            }
+                        ],
+                    },
+                });
+
+                var promotionResult = [
+                    'event',
+                    'select_promotion',
+                    {
+                        promotion_id: 'P_12345',
+                        promotion_name: 'Summer Sale Banner',
+                        creative_name: 'Summer Sale',
+                        creative_slot: 'featured_app_1',
+                        foo: 'bar',
+                        send_to: 'testMeasurementId',
+                    },
+                ];
+
+                window.dataLayer[0].should.eql(promotionResult);
+
+                done();
+            });
+
+            it('should include promotion view event custom attributes on GA4 view_promotion event', function (done) {
+                mParticle.forwarder.process({
+                    CurrencyCode: 'USD',
+                    EventName: 'Test Promotion Action Event',
+                    EventDataType: MessageType.Commerce,
+                    EventCategory: CommerceEventType.PromotionView,
+                    EventAttributes: {"foo": "bar"},
+                    PromotionAction: {
+                        PromotionActionType: PromotionActionType.PromotionView,
+                        PromotionList: [
+                            {
+                                Id: 'P_12345',
+                                Name: 'Summer Sale Banner',
+                                Creative: 'Summer Sale',
+                                Position: 'featured_app_1',
+                            }
+                        ],
+                    },
+                });
+
+                var promotionResult = [
+                    'event',
+                    'view_promotion',
+                    {
+                        promotion_id: 'P_12345',
+                        promotion_name: 'Summer Sale Banner',
+                        creative_name: 'Summer Sale',
+                        creative_slot: 'featured_app_1',
+                        foo: 'bar',
+                        send_to: 'testMeasurementId',
+                    },
+                ];
+
+                window.dataLayer[0].should.eql(promotionResult);
+
+                done();
+            });
         });
     });
 

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -2395,7 +2395,6 @@ describe('Google Analytics 4 Event', function () {
                     EventAttributes: {"foo": "bar"},
                     ProductImpressions: [
                         {
-                            // TODO: Does this map to the name or id of the impression?
                             ProductImpressionList: 'Related Products',
                             ProductList: [
                                 {


### PR DESCRIPTION
## Summary
same issue as this [PR](https://github.com/mparticle-integrations/mparticle-android-integration-google-analytics-firebase-ga4/pull/90) for the Android, where custom attributes for both impression and promotion events don't forward. Right now the only kit that forwards them is the iOS GA4 Firebase kit

## Testing Plan
- Unit testing included and passed
- E2E testing with local overrides showed attributes in GA4 dashboard

## Master Issue
Closes https://mparticle-eng.atlassian.net/browse/PRODRDMP-7123
