### PR TITLE
fix: send default and update consent payloads on kit init

### DIFF
--- a/packages/GA4Client/src/consent.js
+++ b/packages/GA4Client/src/consent.js
@@ -46,12 +46,6 @@ ConsentHandler.prototype.getUserConsentState = function () {
     return userConsentState;
 };
 
-ConsentHandler.prototype.getEventConsentState = function (eventConsentState) {
-    return eventConsentState && eventConsentState.getGDPRConsentState
-        ? eventConsentState.getGDPRConsentState()
-        : {};
-};
-
 ConsentHandler.prototype.getConsentSettings = function () {
     var consentSettings = {};
 

--- a/packages/GA4Client/src/event-handler.js
+++ b/packages/GA4Client/src/event-handler.js
@@ -2,32 +2,6 @@ function EventHandler(common) {
     this.common = common || {};
 }
 
-EventHandler.prototype.maybeSendConsentUpdateToGa4 = function (event) {
-    // If consent payload is empty,
-    // we never sent an initial default consent state
-    // so we shouldn't send an update.
-    if (this.common.consentPayloadAsString && this.common.consentMappings) {
-        var eventConsentState = this.common.consentHandler.getEventConsentState(
-            event.ConsentState
-        );
-
-        if (!this.common.isEmpty(eventConsentState)) {
-            var updatedConsentPayload =
-                this.common.consentHandler.generateConsentStatePayloadFromMappings(
-                    eventConsentState,
-                    this.common.consentMappings
-                );
-
-            var eventConsentAsString = JSON.stringify(updatedConsentPayload);
-
-            if (eventConsentAsString !== this.common.consentPayloadAsString) {
-                gtag('consent', 'update', updatedConsentPayload);
-                this.common.consentPayloadAsString = eventConsentAsString;
-            }
-        }
-    }
-};
-
 // TODO: https://mparticle-eng.atlassian.net/browse/SQDSDKS-5715
 EventHandler.prototype.sendEventToGA4 = function (eventName, eventAttributes) {
     var standardizedEventName;
@@ -58,7 +32,10 @@ EventHandler.prototype.sendEventToGA4 = function (eventName, eventAttributes) {
 };
 
 EventHandler.prototype.logEvent = function (event) {
-    this.maybeSendConsentUpdateToGa4(event);
+    var eventConsentState = this.common.getEventConsentState(
+        event.ConsentState
+    );
+    this.common.maybeSendConsentUpdateToGoogle(eventConsentState);
     this.sendEventToGA4(event.EventName, event.EventAttributes);
 };
 
@@ -109,7 +86,10 @@ EventHandler.prototype.logPageView = function (event) {
         event.EventAttributes
     );
 
-    this.maybeSendConsentUpdateToGa4(event);
+    var eventConsentState = this.common.getEventConsentState(
+        event.ConsentState
+    );
+    this.common.maybeSendConsentUpdateToGoogle(eventConsentState);
     this.sendEventToGA4('page_view', eventAttributes);
 
     return true;

--- a/packages/GA4Client/src/initialization.js
+++ b/packages/GA4Client/src/initialization.js
@@ -105,21 +105,25 @@ var initialization = {
 
         common.consentPayloadDefaults =
             common.consentHandler.getConsentSettings();
-        var initialConsentState = common.consentHandler.getUserConsentState();
-
-        var defaultConsentPayload =
+        var defaultConsentPayload = common.cloneObject(
+            common.consentPayloadDefaults
+        );
+        var updatedConsentState = common.consentHandler.getUserConsentState();
+        var updatedDefaultConsentPayload =
             common.consentHandler.generateConsentStatePayloadFromMappings(
-                initialConsentState,
+                updatedConsentState,
                 common.consentMappings
             );
 
         if (!common.isEmpty(defaultConsentPayload)) {
-            common.consentPayloadAsString = JSON.stringify(
-                defaultConsentPayload
+            common.sendDefaultConsentPayloadToGoogle(defaultConsentPayload);
+        } else if (!common.isEmpty(updatedDefaultConsentPayload)) {
+            common.sendDefaultConsentPayloadToGoogle(
+                updatedDefaultConsentPayload
             );
-
-            gtag('consent', 'default', defaultConsentPayload);
         }
+
+        common.maybeSendConsentUpdateToGoogle(updatedConsentState);
 
         return isInitialized;
     },

--- a/packages/GA4Client/src/initialization.js
+++ b/packages/GA4Client/src/initialization.js
@@ -116,8 +116,11 @@ var initialization = {
             );
 
         if (!common.isEmpty(defaultConsentPayload)) {
+            // If a default consent payload exists (as selected in the mParticle UI), set it as the default
             common.sendDefaultConsentPayloadToGoogle(defaultConsentPayload);
         } else if (!common.isEmpty(updatedDefaultConsentPayload)) {
+            // If a default consent payload does not exist, but the user currently has updated their consent,
+            // send that as the default because a default must be sent
             common.sendDefaultConsentPayloadToGoogle(
                 updatedDefaultConsentPayload
             );

--- a/packages/GA4Client/src/initialization.js
+++ b/packages/GA4Client/src/initialization.js
@@ -115,12 +115,12 @@ var initialization = {
                 common.consentMappings
             );
 
+        // If a default consent payload exists (as selected in the mParticle UI), set it as the default
         if (!common.isEmpty(defaultConsentPayload)) {
-            // If a default consent payload exists (as selected in the mParticle UI), set it as the default
             common.sendDefaultConsentPayloadToGoogle(defaultConsentPayload);
+        // If a default consent payload does not exist, but the user currently has updated their consent,
+        // send that as the default because a default must be sent
         } else if (!common.isEmpty(updatedDefaultConsentPayload)) {
-            // If a default consent payload does not exist, but the user currently has updated their consent,
-            // send that as the default because a default must be sent
             common.sendDefaultConsentPayloadToGoogle(
                 updatedDefaultConsentPayload
             );

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -2914,7 +2914,8 @@ describe('Google Analytics 4 Event', function () {
             ];
 
             // Initial elements of Data Layer are setup for gtag.
-            // Consent state should be on the bottom
+            // Default Consent payload from default settings should be index 3
+            // Update Consent payload from mappings should be on the bottom (index 4)
             window.dataLayer.length.should.eql(5);
             window.dataLayer[3][0].should.equal('consent');
             window.dataLayer[3][1].should.equal('default');
@@ -2978,7 +2979,8 @@ describe('Google Analytics 4 Event', function () {
 
             // Initial elements of Data Layer are setup for gtag.
             // Consent Default is index 3
-            // Consent Update is index 5
+            // Initial Consent Update from mappings is index 4
+            // Consent Update #2 is index 5
             // Event is index 6
             window.dataLayer.length.should.eql(7);
             window.dataLayer[5][0].should.equal('consent');
@@ -3050,9 +3052,10 @@ describe('Google Analytics 4 Event', function () {
 
             // Initial elements of Data Layer are setup for gtag.
             // Consent Default is index 3
-            // Consent Update is index 5
+            // Initial Consent Update from mappings is index 4
+            // Consent Update #2 is index 5
             // Event is index 6
-            // Consent Update #2 is index 7
+            // Consent Update #3 is index 7
             // Event #2 is index 8
             window.dataLayer.length.should.eql(9);
             window.dataLayer[7][0].should.equal('consent');

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -2628,7 +2628,7 @@ describe('Google Analytics 4 Event', function () {
             done();
         });
 
-        it('should merge Consent Setting Defaults with User Consent State to construct a Default Consent State', (done) => {
+        it('should construct a Default Consent State Payload from Default Settings and construct an Update Consent State Payload from Mappings', (done) => {
             mParticle.forwarder.init(
                 {
                     conversionId: 'AW-123123123',
@@ -2643,9 +2643,20 @@ describe('Google Analytics 4 Event', function () {
                 true
             );
 
-            var expectedDataLayer = [
+            var expectedDataLayer1 = [
                 'consent',
                 'default',
+                {
+                    ad_personalization: 'granted', // From Consent Settings
+                    ad_user_data: 'granted', // From Consent Settings
+                    ad_storage: 'granted', // From Consent Settings
+                    analytics_storage: 'granted', // From Consent Settings
+                },
+            ];
+
+            var expectedDataLayer2 = [
+                'consent',
+                'update',
                 {
                     ad_personalization: 'denied', // From User Consent State
                     ad_user_data: 'denied', // From User Consent State
@@ -2656,10 +2667,13 @@ describe('Google Analytics 4 Event', function () {
 
             // Initial elements of Data Layer are setup for gtag.
             // Consent state should be on the bottom
-            window.dataLayer.length.should.eql(4);
+            window.dataLayer.length.should.eql(5);
             window.dataLayer[3][0].should.equal('consent');
             window.dataLayer[3][1].should.equal('default');
-            window.dataLayer[3][2].should.deepEqual(expectedDataLayer[2]);
+            window.dataLayer[3][2].should.deepEqual(expectedDataLayer1[2]);
+            window.dataLayer[4][0].should.equal('consent');
+            window.dataLayer[4][1].should.equal('update');
+            window.dataLayer[4][2].should.deepEqual(expectedDataLayer2[2]);
 
             done();
         });
@@ -2877,7 +2891,18 @@ describe('Google Analytics 4 Event', function () {
                 true
             );
 
-            var expectedDataLayerBefore = [
+            var expectedDataLayerBefore1 = [
+                'consent',
+                'default',
+                {
+                    ad_personalization: 'granted', // From Consent Settings
+                    ad_user_data: 'granted', // From Consent Settings
+                    ad_storage: 'granted', // From Consent Settings
+                    analytics_storage: 'granted', // From Consent Settings
+                },
+            ];
+
+            var expectedDataLayerBefore2 = [
                 'consent',
                 'update',
                 {
@@ -2890,10 +2915,13 @@ describe('Google Analytics 4 Event', function () {
 
             // Initial elements of Data Layer are setup for gtag.
             // Consent state should be on the bottom
-            window.dataLayer.length.should.eql(4);
+            window.dataLayer.length.should.eql(5);
             window.dataLayer[3][0].should.equal('consent');
             window.dataLayer[3][1].should.equal('default');
-            window.dataLayer[3][2].should.deepEqual(expectedDataLayerBefore[2]);
+            window.dataLayer[3][2].should.deepEqual(expectedDataLayerBefore1[2]);
+            window.dataLayer[4][0].should.equal('consent');
+            window.dataLayer[4][1].should.equal('update');
+            window.dataLayer[4][2].should.deepEqual(expectedDataLayerBefore2[2]);
 
             mParticle.forwarder.process({
                 EventName: 'Homepage',
@@ -2950,12 +2978,12 @@ describe('Google Analytics 4 Event', function () {
 
             // Initial elements of Data Layer are setup for gtag.
             // Consent Default is index 3
-            // Consent Update is index 4
-            // Event is index 5
-            window.dataLayer.length.should.eql(6);
-            window.dataLayer[4][0].should.equal('consent');
-            window.dataLayer[4][1].should.equal('update');
-            window.dataLayer[4][2].should.deepEqual(expectedDataLayerAfter[2]);
+            // Consent Update is index 5
+            // Event is index 6
+            window.dataLayer.length.should.eql(7);
+            window.dataLayer[5][0].should.equal('consent');
+            window.dataLayer[5][1].should.equal('update');
+            window.dataLayer[5][2].should.deepEqual(expectedDataLayerAfter[2]);
 
             mParticle.forwarder.process({
                 EventName: 'Homepage',
@@ -3022,14 +3050,14 @@ describe('Google Analytics 4 Event', function () {
 
             // Initial elements of Data Layer are setup for gtag.
             // Consent Default is index 3
-            // Consent Update is index 4
-            // Event is index 5
-            // Consent Update #2 is index 6
-            // Event #2 is index 7
-            window.dataLayer.length.should.eql(8);
-            window.dataLayer[6][0].should.equal('consent');
-            window.dataLayer[6][1].should.equal('update');
-            window.dataLayer[6][2].should.deepEqual(expectedDataLayerFinal[2]);
+            // Consent Update is index 5
+            // Event is index 6
+            // Consent Update #2 is index 7
+            // Event #2 is index 8
+            window.dataLayer.length.should.eql(9);
+            window.dataLayer[7][0].should.equal('consent');
+            window.dataLayer[7][1].should.equal('update');
+            window.dataLayer[7][2].should.deepEqual(expectedDataLayerFinal[2]);
             done();
         });
 


### PR DESCRIPTION
## Summary
- Same summary as this [PR](https://github.com/mparticle-integrations/mparticle-javascript-integration-google-tag-manager/pull/51) we had for the GTM kit

## Testing Plan
- [Y] Was this tested locally? If not, explain why.
- Tested E2E locally with overrides as well as unit tested

## Master Issue
Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-6815