### PR TITLE
feat: add new consent settings

### DIFF
--- a/packages/GA4Client/src/consent.js
+++ b/packages/GA4Client/src/consent.js
@@ -19,6 +19,9 @@ var googleConsentProperties = [
     'ad_user_data',
     'ad_personalization',
     'analytics_storage',
+    'functionality_storage',
+    'personalization_storage',
+    'security_storage',
 ];
 
 function ConsentHandler(common) {
@@ -54,6 +57,9 @@ ConsentHandler.prototype.getConsentSettings = function () {
         ad_personalization: 'defaultAdPersonalizationConsentSDK',
         ad_storage: 'defaultAdStorageConsentSDK',
         analytics_storage: 'defaultAnalyticsStorageConsentSDK',
+        functionality_storage: 'defaultFunctionalityStorageConsentSDK',
+        personalization_storage: 'defaultPersonalizationStorageConsentSDK',
+        security_storage: 'defaultSecurityStorageConsentSDK',
     };
 
     var forwarderSettings = this.common.forwarderSettings;

--- a/packages/GA4Client/test/src/tests.js
+++ b/packages/GA4Client/test/src/tests.js
@@ -126,6 +126,21 @@ describe('Google Analytics 4 Event', function () {
                                     Timestamp: 1,
                                     Document: 'test_consent',
                                 },
+                                functionality_consent: {
+                                    Consented: false,
+                                    Timestamp: 1,
+                                    Document: 'functionality_consent',
+                                },
+                                personalization_consent: {
+                                    Consented: false,
+                                    Timestamp: 1,
+                                    Document: 'personalization_consent',
+                                },
+                                security_consent: {
+                                    Consented: false,
+                                    Timestamp: 1,
+                                    Document: 'security_consent',
+                                },
                             };
                         },
                     };
@@ -2679,6 +2694,24 @@ describe('Google Analytics 4 Event', function () {
                 maptype: 'ConsentPurposes',
                 value: 'ad_personalization',
             },
+            {
+                jsmap: null,
+                map: 'Functionality_consent',
+                maptype: 'ConsentPurposes',
+                value: 'functionality_storage',
+            },
+            {
+                jsmap: null,
+                map: 'Personalization_consent',
+                maptype: 'ConsentPurposes',
+                value: 'personalization_storage',
+            },
+            {
+                jsmap: null,
+                map: 'Security_consent',
+                maptype: 'ConsentPurposes',
+                value: 'security_storage',
+            },
         ];
 
         beforeEach(function () {
@@ -2690,7 +2723,7 @@ describe('Google Analytics 4 Event', function () {
                 {
                     conversionId: 'AW-123123123',
                     consentMappingSDK:
-                        '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;Some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;Storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;Other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;Test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;}]',
+                        '[{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;Some_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_user_data&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;Storage_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;analytics_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;Other_test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;Test_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;ad_personalization&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;Functionality_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;functionality_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;Personalization_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;personalization_storage&quot;},{&quot;jsmap&quot;:null,&quot;map&quot;:&quot;Security_consent&quot;,&quot;maptype&quot;:&quot;ConsentPurposes&quot;,&quot;value&quot;:&quot;security_storage&quot;}]',
                 },
                 reportService.cb,
                 true
@@ -2702,6 +2735,9 @@ describe('Google Analytics 4 Event', function () {
                 {
                     ad_user_data: 'denied',
                     ad_personalization: 'denied',
+                    functionality_storage: 'denied',
+                    personalization_storage: 'denied',
+                    security_storage: 'denied',
                 },
             ];
 
@@ -2748,6 +2784,9 @@ describe('Google Analytics 4 Event', function () {
                     ad_user_data: 'denied', // From User Consent State
                     ad_storage: 'granted', // From Consent Settings
                     analytics_storage: 'granted', // From Consent Settings
+                    functionality_storage: 'denied', // From User Consent State
+                    personalization_storage: 'denied', // From User Consent State
+                    security_storage: 'denied', // From User Consent State
                 },
             ];
 
@@ -2785,6 +2824,9 @@ describe('Google Analytics 4 Event', function () {
                 {
                     ad_personalization: 'denied', // From User Consent State
                     ad_user_data: 'denied', // From User Consent State
+                    functionality_storage: 'denied', // From User Consent State
+                    personalization_storage: 'denied', // From User Consent State
+                    security_storage: 'denied', // From User Consent State
                 },
             ];
 
@@ -2815,6 +2857,9 @@ describe('Google Analytics 4 Event', function () {
                 {
                     ad_user_data: 'denied',
                     ad_personalization: 'denied',
+                    functionality_storage: 'denied',
+                    personalization_storage: 'denied',
+                    security_storage: 'denied',
                 },
             ];
 
@@ -2996,6 +3041,9 @@ describe('Google Analytics 4 Event', function () {
                     ad_user_data: 'denied', // From User Consent State
                     ad_storage: 'granted', // From Consent Settings
                     analytics_storage: 'granted', // From Consent Settings
+                    functionality_storage: 'denied', // From User Consent State
+                    personalization_storage: 'denied', // From User Consent State
+                    security_storage: 'denied', // From User Consent State
                 },
             ];
 
@@ -3167,6 +3215,9 @@ describe('Google Analytics 4 Event', function () {
                 {
                     ad_user_data: 'denied',
                     ad_personalization: 'denied',
+                    functionality_storage: 'denied',
+                    personalization_storage: 'denied',
+                    security_storage: 'denied',
                 },
             ];
 
@@ -3198,6 +3249,21 @@ describe('Google Analytics 4 Event', function () {
                                 Consented: false,
                                 Timestamp: Date.now(),
                                 Document: 'test_consent',
+                            },
+                            functionality_consent: {
+                                Consented: false,
+                                Timestamp: Date.now(),
+                                Document: 'functionality_consent',
+                            },
+                            personalization_consent: {
+                                Consented: false,
+                                Timestamp: Date.now(),
+                                Document: 'personalization_consent',
+                            },
+                            security_consent: {
+                                Consented: false,
+                                Timestamp: Date.now(),
+                                Document: 'security_consent',
                             },
                         };
                     },


### PR DESCRIPTION
## Summary
- Adds support for three additional Google consent types: functionality_storage, personalization_storage, and security_storage
- Adds corresponding settings mappings (defaultFunctionalityStorageConsentWeb, defaultPersonalizationStorageConsentWeb, defaultSecurityStorageConsentWeb) so they can be configured as defaults in the GA4 forwarder settings

## Testing Plan
Updated unit tests to include functionality_storage, personalization_storage, and security_storage, verifying consent payloads are correctly generated for all seven consent types in initialization and event-processing scenarios.
                                                    
## Master Issue
Closes https://go/j/1139
